### PR TITLE
feat(tests): enhance role-based navigation tests and improve user setup

### DIFF
--- a/e2e/role-based-navigation.spec.js
+++ b/e2e/role-based-navigation.spec.js
@@ -1,286 +1,314 @@
 import { test, expect } from '@playwright/test'
 
 test.describe('Role-Based Navigation and Routing', () => {
-    // Test data - mock users
-    const adminUser = {
-        email: 'admin@moussawer.test',
-        password: 'AdminPassword123!'
+    // Test users - these should be created via tinker commands in setup
+    const testUsers = {
+        admin: {
+            email: 'admin@example.com',
+            password: 'AdminPassword123!',
+            role: 'admin',
+            dashboardPath: '/admin/dashboard',
+        },
+        photographer: {
+            email: 'photographer@example.com',
+            password: 'PhotographerPassword123!',
+            role: 'photographer',
+            dashboardPath: '/photographer/dashboard',
+        },
+        client: {
+            email: 'client@example.com',
+            password: 'ClientPassword123!',
+            role: 'client',
+            dashboardPath: '/client/dashboard',
+        },
     }
-    
-    const photographerUser = {
-        email: 'photographer@moussawer.test',
-        password: 'PhotographerPassword123!'
-    }
-    
-    const clientUser = {
-        email: 'client@moussawer.test',
-        password: 'ClientPassword123!'
-    }
 
-    test('Admin dashboard redirects correctly on login', async ({ page }) => {
-        // Go to login page
-        await page.goto('http://localhost:5173/login')
-        
-        // Check we're on login page
-        await expect(page).toHaveURL(/\/login/)
-        
-        // Attempt to register as admin (if needed) or login
-        await page.fill('input[name="email"]', adminUser.email)
-        await page.fill('input[name="password"]', adminUser.password)
-        
-        // Click login button
-        await page.click('button:has-text("Login")')
-        
-        // Wait for redirect to admin dashboard
-        await page.waitForURL(/\/admin\/dashboard/, { timeout: 5000 }).catch(() => {
-            // If admin credentials don't exist, skip this assertion
-            return
-        })
+    /**
+     * Setup commands (run once before tests):
+     * Admin:     vendor/bin/sail artisan tinker --execute="App\Models\User::factory()->create(['role' => 'admin', 'email' => 'admin@example.com', 'password' => bcrypt('AdminPassword123!')])"
+     * Photographer: vendor/bin/sail artisan tinker --execute="App\Models\User::factory()->create(['role' => 'photographer', 'email' => 'photographer@example.com', 'password' => bcrypt('PhotographerPassword123!')])"
+     * Client:    vendor/bin/sail artisan tinker --execute="App\Models\User::factory()->create(['role' => 'client', 'email' => 'client@example.com', 'password' => bcrypt('ClientPassword123!')])"
+     */
+
+    test.describe('Login redirects based on user role', () => {
+        for (const [role, user] of Object.entries(testUsers)) {
+            test(`${role} user is redirected to their dashboard after login`, async ({ page }) => {
+                // Go to login page and wait for it to load
+                await page.goto('/login')
+                await page.waitForLoadState('networkidle')
+
+                // Verify we're on the login page
+                await expect(page).toHaveURL(/\/login/)
+
+                // Fill in login form
+                await page.fill('input[name="email"]', user.email)
+                await page.fill('input[name="password"]', user.password)
+
+                // Submit login
+                await page.click('button[type="submit"]')
+
+                // Wait for redirect to role-specific dashboard
+                await expect(page).toHaveURL(new RegExp(user.dashboardPath), {
+                    timeout: 10000,
+                })
+
+                // Verify we're on the dashboard
+                await expect(page).toHaveURL(/\/dashboard/)
+            })
+        }
     })
 
-    test('Photographer dashboard redirects correctly on login', async ({ page }) => {
-        // Go to login page
-        await page.goto('http://localhost:5173/login')
-        
-        // Check we're on login page
-        await expect(page).toHaveURL(/\/login/)
-        
-        // Attempt to register as photographer or login
-        await page.fill('input[name="email"]', photographerUser.email)
-        await page.fill('input[name="password"]', photographerUser.password)
-        
-        // Click login button
-        await page.click('button:has-text("Login")')
-        
-        // Wait for redirect to photographer dashboard
-        await page.waitForURL(/\/photographer\/dashboard/, { timeout: 5000 }).catch(() => {
-            // If photographer credentials don't exist, skip this assertion
-            return
-        })
-    })
-
-    test('Client dashboard redirects correctly on login', async ({ page }) => {
-        // Go to login page
-        await page.goto('http://localhost:5173/login')
-        
-        // Check we're on login page
-        await expect(page).toHaveURL(/\/login/)
-        
-        // Attempt to register as client or login
-        await page.fill('input[name="email"]', clientUser.email)
-        await page.fill('input[name="password"]', clientUser.password)
-        
-        // Click login button
-        await page.click('button:has-text("Login")')
-        
-        // Wait for redirect to client dashboard
-        await page.waitForURL(/\/client\/dashboard/, { timeout: 5000 }).catch(() => {
-            // If client credentials don't exist, skip this assertion
-            return
-        })
-    })
-
-    test('Authenticated users redirected from login page', async ({ page, context }) => {
-        // First, register/login as a test user
-        await page.goto('http://localhost:5173/login')
-        
-        // Assuming we can login with a test account
-        // Set auth token in localStorage to simulate authenticated state
-        await page.evaluate(() => {
-            localStorage.setItem('auth_token', 'test-token-123')
-            localStorage.setItem('auth_user', JSON.stringify({
-                id: 1,
-                name: 'Test User',
-                email: 'test@moussawer.test',
-                role: 'client'
-            }))
-        })
-        
-        // Reload and navigate to login
-        await page.goto('http://localhost:5173/login')
-        
-        // Should redirect away from login
-        await page.waitForTimeout(1000)
-        
-        // Check that we're not on the login page anymore
-        const url = page.url()
-        const isNotOnLogin = !url.includes('/login')
-        expect(isNotOnLogin || url.includes('localhost')).toBeTruthy()
-    })
-
-    test('Navigation menu shows correct role-specific links', async ({ page }) => {
-        // Set up authenticated session for photographer
-        await page.evaluate(() => {
-            localStorage.setItem('auth_token', 'test-token-123')
-            localStorage.setItem('auth_user', JSON.stringify({
+    test.describe('Navigation menu shows correct role-specific links', () => {
+        test('Photographer navigation includes photographer-specific links', async ({ page }) => {
+            // Navigate first to set the origin
+            await page.goto('/photographer/dashboard')
+            
+            // Set up authenticated session for photographer
+            await page.evaluate((userData) => {
+                localStorage.setItem('auth_token', 'test-token-123')
+                localStorage.setItem('auth_user', JSON.stringify(userData))
+            }, {
                 id: 1,
                 name: 'Test Photographer',
                 email: 'test@moussawer.test',
-                role: 'photographer'
-            }))
-        })
-        
-        // Navigate to photographer dashboard
-        await page.goto('http://localhost:5173/photographer/dashboard')
-        
-        // Check for photographer-specific navigation items
-        await expect(page.locator('text=Dashboard')).toBeVisible()
-        await expect(page.locator('text=Bookings')).toBeVisible()
-        await expect(page.locator('text=My Profile')).toBeVisible()
-        
-        // Check logout button exists
-        await expect(page.locator('button:has-text("Logout")')).toBeVisible()
-    })
+                role: 'photographer',
+            })
 
-    test('Client navigation menu shows correct role-specific links', async ({ page }) => {
-        // Set up authenticated session for client
-        await page.evaluate(() => {
-            localStorage.setItem('auth_token', 'test-token-123')
-            localStorage.setItem('auth_user', JSON.stringify({
+            // Reload to apply the auth state
+            await page.reload()
+            await page.waitForLoadState('networkidle')
+
+            // Verify photographer-specific navigation items
+            await expect(page.getByRole('link', { name: /dashboard/i }).first()).toBeVisible()
+            await expect(page.getByRole('link', { name: /bookings/i }).first()).toBeVisible()
+            await expect(page.getByRole('link', { name: /profile/i }).first()).toBeVisible()
+            await expect(page.getByRole('button', { name: /logout/i })).toBeVisible()
+        })
+
+        test('Client navigation includes client-specific links', async ({ page }) => {
+            // Navigate first to set the origin
+            await page.goto('/client/dashboard')
+            
+            // Set up authenticated session for client
+            await page.evaluate((userData) => {
+                localStorage.setItem('auth_token', 'test-token-123')
+                localStorage.setItem('auth_user', JSON.stringify(userData))
+            }, {
                 id: 2,
                 name: 'Test Client',
                 email: 'client@moussawer.test',
-                role: 'client'
-            }))
+                role: 'client',
+            })
+
+            // Reload to apply the auth state
+            await page.reload()
+            await page.waitForLoadState('networkidle')
+
+            // Verify client-specific navigation items
+            await expect(page.getByRole('link', { name: /dashboard/i }).first()).toBeVisible()
+            await expect(page.getByRole('link', { name: /my bookings/i }).first()).toBeVisible()
+            await expect(page.getByRole('link', { name: /my profile/i }).first()).toBeVisible()
+            await expect(page.getByRole('button', { name: /logout/i })).toBeVisible()
         })
-        
-        // Navigate to client dashboard
-        await page.goto('http://localhost:5173/client/dashboard')
-        
-        // Check for client-specific navigation items
-        await expect(page.locator('text=Dashboard')).toBeVisible()
-        await expect(page.locator('text=My Bookings')).toBeVisible()
-        await expect(page.locator('text=My Profile')).toBeVisible()
-        
-        // Check logout button exists
-        await expect(page.locator('button:has-text("Logout")')).toBeVisible()
     })
 
-    test('Photographer can navigate between their dashboard sections', async ({ page }) => {
-        // Set up authenticated session for photographer
-        await page.evaluate(() => {
-            localStorage.setItem('auth_token', 'test-token-123')
-            localStorage.setItem('auth_user', JSON.stringify({
+    test.describe('Internal navigation within role dashboards', () => {
+        test('Photographer can navigate between dashboard sections', async ({ page }) => {
+            // Navigate first to set the origin
+            await page.goto('/photographer/dashboard')
+            
+            // Set up authenticated session
+            await page.evaluate((userData) => {
+                localStorage.setItem('auth_token', 'test-token-123')
+                localStorage.setItem('auth_user', JSON.stringify(userData))
+            }, {
                 id: 1,
                 name: 'Test Photographer',
                 email: 'test@moussawer.test',
-                role: 'photographer'
-            }))
-        })
-        
-        // Navigate to photographer dashboard
-        await page.goto('http://localhost:5173/photographer/dashboard')
-        
-        // Click on Bookings link
-        await page.click('a:has-text("Bookings")')
-        
-        // Should navigate to bookings page
-        await expect(page).toHaveURL(/\/photographer\/bookings/)
-        
-        // Click on Profile link
-        await page.click('a:has-text("My Profile")')
-        
-        // Should navigate to profile page
-        await expect(page).toHaveURL(/\/photographer\/profile/)
-        
-        // Click on Dashboard link
-        await page.click('a:has-text("Dashboard")')
-        
-        // Should navigate back to dashboard
-        await expect(page).toHaveURL(/\/photographer\/dashboard/)
-    })
+                role: 'photographer',
+            })
 
-    test('Client can navigate between their dashboard sections', async ({ page }) => {
-        // Set up authenticated session for client
-        await page.evaluate(() => {
-            localStorage.setItem('auth_token', 'test-token-123')
-            localStorage.setItem('auth_user', JSON.stringify({
+            // Reload to apply the auth state
+            await page.reload()
+            await page.waitForLoadState('networkidle')
+            await expect(page).toHaveURL(/\/photographer\/dashboard/)
+
+            // Navigate to Bookings
+            await page.getByRole('link', { name: /bookings/i }).first().click()
+            await expect(page).toHaveURL(/\/photographer\/bookings/)
+
+            // Navigate to Profile
+            await page.getByRole('link', { name: /profile/i }).first().click()
+            await expect(page).toHaveURL(/\/photographer\/profile/)
+
+            // Navigate back to Dashboard
+            await page.getByRole('link', { name: /dashboard/i }).first().click()
+            await expect(page).toHaveURL(/\/photographer\/dashboard/)
+        })
+
+        test('Client can navigate between dashboard sections', async ({ page }) => {
+            // Navigate first to set the origin
+            await page.goto('/client/dashboard')
+            
+            // Set up authenticated session
+            await page.evaluate((userData) => {
+                localStorage.setItem('auth_token', 'test-token-123')
+                localStorage.setItem('auth_user', JSON.stringify(userData))
+            }, {
                 id: 2,
                 name: 'Test Client',
                 email: 'client@moussawer.test',
-                role: 'client'
-            }))
+                role: 'client',
+            })
+
+            // Reload to apply the auth state
+            await page.reload()
+            await page.waitForLoadState('networkidle')
+            await expect(page).toHaveURL(/\/client\/dashboard/)
+
+            // Navigate to My Bookings
+            await page.getByRole('link', { name: /my bookings/i }).first().click()
+            await expect(page).toHaveURL(/\/client\/bookings/)
+
+            // Navigate to My Profile
+            await page.getByRole('link', { name: /my profile/i }).first().click()
+            await expect(page).toHaveURL(/\/client\/profile/)
+
+            // Navigate back to Dashboard
+            await page.getByRole('link', { name: /dashboard/i }).first().click()
+            await expect(page).toHaveURL(/\/client\/dashboard/)
         })
-        
-        // Navigate to client dashboard
-        await page.goto('http://localhost:5173/client/dashboard')
-        
-        // Click on My Bookings link
-        await page.click('a:has-text("My Bookings")')
-        
-        // Should navigate to bookings page
-        await expect(page).toHaveURL(/\/client\/bookings/)
-        
-        // Click on My Profile link
-        await page.click('a:has-text("My Profile")')
-        
-        // Should navigate to profile page
-        await expect(page).toHaveURL(/\/client\/profile/)
-        
-        // Click on Dashboard link
-        await page.click('a:has-text("Dashboard")')
-        
-        // Should navigate back to dashboard
-        await expect(page).toHaveURL(/\/client\/dashboard/)
     })
 
-    test('Logout button clears session and redirects to login', async ({ page }) => {
-        // Set up authenticated session
-        await page.evaluate(() => {
-            localStorage.setItem('auth_token', 'test-token-123')
-            localStorage.setItem('auth_user', JSON.stringify({
+    test.describe('Authentication guards', () => {
+        test('Logout clears session and redirects to login', async ({ page }) => {
+            // Navigate first
+            await page.goto('/client/dashboard')
+            
+            // Set up authenticated session
+            await page.evaluate((userData) => {
+                localStorage.setItem('auth_token', 'test-token-123')
+                localStorage.setItem('auth_user', JSON.stringify(userData))
+            }, {
                 id: 1,
                 name: 'Test User',
                 email: 'test@moussawer.test',
-                role: 'client'
-            }))
+                role: 'client',
+            })
+
+            // Reload to apply the auth state
+            await page.reload()
+            await page.waitForLoadState('networkidle')
+            await expect(page).toHaveURL(/\/client\/dashboard/)
+
+            // Click logout button
+            await page.getByRole('button', { name: /logout/i }).click()
+
+            // Should redirect to login page
+            await expect(page).toHaveURL(/\/login/)
+
+            // Auth data should be cleared
+            await expect(page.evaluate(() => localStorage.getItem('auth_token'))).toBeNull()
+            await expect(page.evaluate(() => localStorage.getItem('auth_user'))).toBeNull()
         })
-        
-        // Navigate to dashboard
-        await page.goto('http://localhost:5173/client/dashboard')
-        
-        // Click logout button
-        await page.click('button:has-text("Logout")')
-        
-        // Should redirect to login page
-        await expect(page).toHaveURL(/\/login/)
+
+        test('Authenticated users are redirected from login page', async ({ page }) => {
+            // Navigate to login page first
+            await page.goto('/login')
+            
+            // Set up authenticated session
+            await page.evaluate((userData) => {
+                localStorage.setItem('auth_token', 'test-token-123')
+                localStorage.setItem('auth_user', JSON.stringify(userData))
+            }, {
+                id: 1,
+                name: 'Test User',
+                email: 'test@moussawer.test',
+                role: 'client',
+            })
+
+            // Reload - should redirect to client dashboard
+            await page.reload()
+            await page.waitForLoadState('networkidle')
+
+            // Should be redirected to client dashboard (role-based redirect)
+            await expect(page).toHaveURL(/\/client\/dashboard/)
+        })
+
+        test('Unauthenticated users accessing protected routes are redirected to login', async ({ page }) => {
+            // Clear any auth data
+            await page.goto('/')
+            await page.evaluate(() => {
+                localStorage.removeItem('auth_token')
+                localStorage.removeItem('auth_user')
+            })
+
+            // Try to access photographer dashboard directly
+            await page.goto('/photographer/dashboard')
+            await page.waitForLoadState('networkidle')
+
+            // Should redirect to login page
+            await expect(page).toHaveURL(/\/login/)
+        })
     })
 
-    test('Direct access to protected routes redirects unauthenticated users to login', async ({ page }) => {
-        // Clear any auth data
-        await page.evaluate(() => {
-            localStorage.removeItem('auth_token')
-            localStorage.removeItem('auth_user')
-        })
-        
-        // Try to access photographer dashboard directly
-        await page.goto('http://localhost:5173/photographer/dashboard')
-        
-        // Should redirect to login page
-        await expect(page).toHaveURL(/\/login/)
-    })
-
-    test('Dashboard styles reflect role (photographer uses blue, client uses green)', async ({ page }) => {
-        // Set up photographer session
-        await page.evaluate(() => {
-            localStorage.setItem('auth_token', 'test-token-123')
-            localStorage.setItem('auth_user', JSON.stringify({
+    test.describe('Role-based access control', () => {
+        test('Photographer cannot access client routes', async ({ page }) => {
+            // Navigate first
+            await page.goto('/photographer/dashboard')
+            
+            // Set up photographer session
+            await page.evaluate((userData) => {
+                localStorage.setItem('auth_token', 'test-token-123')
+                localStorage.setItem('auth_user', JSON.stringify(userData))
+            }, {
                 id: 1,
                 name: 'Test Photographer',
                 email: 'test@moussawer.test',
-                role: 'photographer'
-            }))
+                role: 'photographer',
+            })
+
+            // Reload to apply the auth state
+            await page.reload()
+            await page.waitForLoadState('networkidle')
+
+            // Try to access client dashboard
+            await page.goto('/client/dashboard')
+            await page.waitForLoadState('networkidle')
+
+            // Should be redirected (either to unauthorized or back to photographer dashboard)
+            const url = page.url()
+            const hasAccess = url.includes('/client/dashboard')
+            expect(hasAccess).toBe(false)
         })
-        
-        // Navigate to photographer dashboard
-        await page.goto('http://localhost:5173/photographer/dashboard')
-        
-        // Check for blue theme elements in photographer layout
-        const navStyle = await page.locator('nav.navbar').first().evaluate(el => {
-            return getComputedStyle(el).borderColor || 'none'
+
+        test('Client cannot access photographer routes', async ({ page }) => {
+            // Navigate first
+            await page.goto('/client/dashboard')
+            
+            // Set up client session
+            await page.evaluate((userData) => {
+                localStorage.setItem('auth_token', 'test-token-123')
+                localStorage.setItem('auth_user', JSON.stringify(userData))
+            }, {
+                id: 2,
+                name: 'Test Client',
+                email: 'client@moussawer.test',
+                role: 'client',
+            })
+
+            // Reload to apply the auth state
+            await page.reload()
+            await page.waitForLoadState('networkidle')
+
+            // Try to access photographer dashboard
+            await page.goto('/photographer/dashboard')
+            await page.waitForLoadState('networkidle')
+
+            // Should be redirected
+            const url = page.url()
+            const hasAccess = url.includes('/photographer/dashboard')
+            expect(hasAccess).toBe(false)
         })
-        
-        // Navigation should exist (style details depend on CSS)
-        await expect(page.locator('nav.navbar').first()).toBeVisible()
     })
 })

--- a/resources/js/stores/auth.js
+++ b/resources/js/stores/auth.js
@@ -53,12 +53,13 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
-  async function fetchUser() {
+    async function fetchUser() {
     if (!token.value) return
 
     try {
       const response = await api.get('/user')
-      user.value = response.data   // assuming MeController returns UserResource
+      // MeController returns { user: UserResource }, so extract the user object
+      user.value = response.data.user
     } catch (err) {
       console.error('Failed to fetch user', err)
       // Token probably expired → logout

--- a/resources/js/views/auth/LoginView.vue
+++ b/resources/js/views/auth/LoginView.vue
@@ -8,6 +8,7 @@
         <input
           v-model="form.email"
           type="email"
+          name="email"
           required
           class="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
           :class="{ 'border-red-500': error }"
@@ -19,6 +20,7 @@
         <input
           v-model="form.password"
           type="password"
+          name="password"
           required
           class="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
           :class="{ 'border-red-500': error }"


### PR DESCRIPTION
Fixed the role-based redirect bug after login. The issue was in `resources/js/stores/auth.js` - the `fetchUser()` function was incorrectly setting `user.value = response.data` instead of `user.value = response.data.user`, causing `authStore.user.role` to be undefined and redirecting all users to `/` instead of their role-specific dashboards.

**Changes made:**

1. **`resources/js/stores/auth.js`** (line 62): Fixed `fetchUser()` to correctly extract the user object:
   ```javascript
   // Before: user.value = response.data
   // After:  user.value = response.data.user
   ```

2. **`e2e/role-based-navigation.spec.js`**: Improved the e2e test with:
   - Better organized test structure with `test.describe` blocks
   - Removed flaky heading checks
   - Proper localStorage handling (navigate before setting, then reload)
   - Clearer assertions and better timeout handling
   - Tests for login redirects, navigation menus, internal navigation, auth guards, and role-based access control

**To run the tests**, you'll need to first create test users:
```bash
vendor/bin/sail artisan tinker --execute="App\Models\User::factory()->create(['role' => 'admin', 'email' => 'admin@example.com', 'password' => bcrypt('AdminPassword123!')])"
vendor/bin/sail artisan tinker --execute="App\Models\User::factory()->create(['role' => 'photographer', 'email' => 'photographer@example.com', 'password' => bcrypt('PhotographerPassword123!')])"
vendor/bin/sail artisan tinker --execute="App\Models\User::factory()->create(['role' => 'client', 'email' => 'client@example.com', 'password' => bcrypt('ClientPassword123!')])"
```

Then rebuild and run tests:
```bash
vendor/bin/sail npm run build
vendor/bin/sail npx playwright test e2e/role-based-navigation.spec.js
```