### PR TITLE
fix: update booking status endpoint to use /status suffix

### DIFF
--- a/resources/js/composables/useBookings.js
+++ b/resources/js/composables/useBookings.js
@@ -26,7 +26,7 @@ export function useBookings() {
 
   const updateBookingStatus = async (bookingId, status) => {
     try {
-      await api.patch(`/bookings/${bookingId}`, { status })
+      await api.patch(`/bookings/${bookingId}/status`, { status })
     } catch (error) {
       console.error('Failed to update booking status:', error)
       throw error


### PR DESCRIPTION
The frontend was calling PATCH /api/bookings/{id} but the API expects PATCH /api/bookings/{id}/status. This caused a 405 Method Not Allowed error.

Updated useBookings.js to call the correct endpoint.
---