### PR TITLE
feat: add Dockerfile + docker-compose for single-command dev server startup

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -18,7 +18,8 @@
 3. Execute the task.
 4. Validate changes (tests, lint, build, static analysis).
 5. **Simulate real user experience** — use Playwright (browser automation) to navigate the app and verify UI behaviour (routes render, redirects work, loading states show, role-gating works, etc.). Do not rely solely on static checks.
-   - If a dev server / build server is needed but not running, **ask the user to start it** (e.g. `npx vite --port 5173` in a separate terminal) instead of trying to run it in background yourself. Background processes often time out or fail silently.
+   - If a dev server / build server is needed but not running, **ask the user to run** `docker-compose up --build -d` (recommended) which starts both the API (port 4000) and serves the built frontend as static files. The single container runs the Express server which serves both the API routes and the Vite-built frontend.
+     - If Docker is not available, ask the user to run `npm run dev` (starts both Vite frontend on port 5173 and Express API on port 4000 via `concurrently`).
    - Once the user confirms the server is up, proceed with Playwright validation.
 6. After all code changes and validation are complete, **do NOT push or declare done**. Follow the testing documentation at `doc/playwright-mcp-testing.md` to run a structured browser-based validation. Only mark mission complete when all checklist items pass.
 7. Reflect and document improvements.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# ---- Build Stage ----
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# ---- Production Stage ----
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+
+COPY --from=builder /app/dist ./dist
+COPY server/ ./server/
+COPY prisma/ ./prisma/
+COPY tsconfig.json ./
+
+EXPOSE 4000
+
+CMD ["npm", "run", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.9"
+
+services:
+  moussawer:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: moussawer
+    ports:
+      - "4000:4000"
+    environment:
+      - PORT=4000
+      - DATABASE_URL=file:./dev.db
+      - JWT_SECRET=dev-docker-secret-change-in-production
+      - NODE_ENV=production
+    volumes:
+      - ./prisma:/app/prisma
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
Replaces the old 2-terminal workflow for Playwright validation with a single `docker-compose up --build -d` command.

## Changes
- **Dockerfile**: Multi-stage build - Vite builds frontend in stage 1, Express serves both API and built frontend in stage 2
- **docker-compose.yml**: Single service exposing port 4000, mounts prisma/ for SQLite persistence
- **.clinerules**: Updated workflow to recommend docker-compose as primary approach, with npm run dev as fallback

## Usage
AI agents will now ask: "Please run `docker-compose up --build -d` to start the server (API on port 4000)."