### PR TITLE
feat: add kill-playwright-mcp.sh utility to automate stale MCP process cleanup

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -44,6 +44,15 @@ After completing the mission, always provide:
 - Use Python/scripts for repetitive parsing or data operations.
 - Store reusable scripts in a clear dedicated folder.
 
+## Available Utility Scripts
+
+### `scripts/kill-playwright-mcp.sh`
+Kills all stale Playwright MCP processes that persist after a Cline restart.
+Run immediately after restarting Cline to get a clean slate:
+```
+./scripts/kill-playwright-mcp.sh
+```
+Before this script: manual `ps aux | grep playwright` + kill each PID (~2 min).
 ---
 
 ## Code Standards
@@ -194,6 +203,8 @@ git push -u origin <branch>
 - `doc/playwright-mcp-setup.md` — only read this when the Playwright MCP server is not working / throwing errors.
 - `doc/playwright-mcp-testing.md` — only read this when you need to perform validation after code changes (step 6 of Workflow).
 
+### Stale process cleanup
+Before troubleshooting, run `./scripts/kill-playwright-mcp.sh` to kill any stale zombie processes from the previous session.
 ### If the Playwright MCP server fails to initialize:
 1. Read `doc/playwright-mcp-setup.md` to understand how it was installed and configured.
 2. Fix the issue (symlink broken? config reverted? browser missing?).
@@ -247,7 +258,7 @@ git push -u origin <branch>
 - Wrong MCP server ID — used `github.com/microsoft/playwright-mcp` instead of `github.com/executeautomation/mcp-playwright`
 - `--executable-path` flag does NOT work reliably; must use symlink at `/opt/google/chrome/chrome`
 - `--browser chromium` + `--headless` flags are required in args
-- Old MCP processes persist after restart; must kill `ps aux | grep playwright` processes manually
+- Old MCP processes persist after restart — run `./scripts/kill-playwright-mcp.sh` to clean them up
 - Background process launches from command tools time out — must ask user to start servers manually
 
 **Documentation created:**
@@ -255,3 +266,23 @@ git push -u origin <branch>
 - `doc/playwright-mcp-testing.md` — structured testing procedures
 - `.clinerules` — lazy-load rules to avoid wasting context upfront
 
+### 2026-04-28 — MCP Process Health (kill-playwright-mcp.sh)
+
+**What was implemented:**
+- `scripts/kill-playwright-mcp.sh` — kills all stale Playwright MCP processes in one command
+- `pgrep`-based process discovery with `ps` fallback
+- Graceful SIGTERM first, then SIGKILL for survivors
+- Color-coded output showing which PIDs were killed and their commands
+
+**Before:**
+- Manual `ps aux | grep playwright` + identify PIDs + `kill` each one (~2 min)
+- Had to do this every single restart cycle
+
+**After:**
+- `./scripts/kill-playwright-mcp.sh` → clean slate in ~2 seconds
+- Integrated into `.clinerules` as step 0 before Playwright MCP troubleshooting
+
+**Eliminated pain point:**
+- ~2 minutes × many restarts per session → zero time
+- No more identifying PIDs manually
+- No more forgotten zombies causing MCP conflicts

--- a/scripts/kill-playwright-mcp.sh
+++ b/scripts/kill-playwright-mcp.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#===============================================================================
+# Kill Stale Playwright MCP Processes
+# Usage: ./scripts/kill-playwright-mcp.sh
+#
+# After restarting Cline, old MCP server processes with stale arguments persist
+# as zombies. This script kills all running Playwright MCP processes so only
+# freshly spawned (correctly configured) ones remain.
+#
+# Patterns killed:
+#   - npm exec @playwright/mcp@latest
+#   - playwright-mcp (shell subprocess)
+#   - node .../playwright-mcp (actual Node process)
+#
+# Before: manual `ps aux | grep playwright` + kill each PID (~2 min/restart)
+# After:  `./scripts/kill-playwright-mcp.sh` (~2 seconds)
+#===============================================================================
+
+set -euo pipefail
+
+# ---- Colors ----
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# ---- Help ----
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  sed -n '3,16p' "$0"
+  exit 0
+fi
+
+# ---- Find matching PIDs ----
+# We search for three patterns to catch all layers of the Playwright MCP process tree:
+#   1. "npm exec.*playwright" — the npm wrapper
+#   2. "playwright-mcp" — the shell and binary names
+# We use pgrep for reliability; fall back to ps+awk if pgrep unavailable.
+PIDS=""
+
+if command -v pgrep &>/dev/null; then
+  PIDS=$(pgrep -f "@playwright/mcp" 2>/dev/null || true)
+  PIDS_PW=$(pgrep -f "playwright-mcp" 2>/dev/null || true)
+  PIDS="$PIDS $PIDS_PW"
+else
+  # Fallback: use ps + grep + awk
+  PIDS=$(ps aux | grep -E '@playwright/mcp|playwright-mcp' | grep -v grep | awk '{print $2}' | tr '\n' ' ')
+fi
+
+# Deduplicate and trim
+PIDS=$(echo "$PIDS" | tr ' ' '\n' | grep -v '^$' | sort -u | tr '\n' ' ')
+
+if [[ -z "$PIDS" || "$PIDS" =~ ^[[:space:]]*$ ]]; then
+  echo -e "${GREEN}✓ No stale Playwright MCP processes found.${NC}"
+  exit 0
+fi
+
+# ---- Kill ----
+COUNT=0
+for PID in $PIDS; do
+  # Verify the process still exists before trying to kill
+  if kill -0 "$PID" 2>/dev/null; then
+    # Get process info for logging
+    CMD=$(ps -o args= -p "$PID" 2>/dev/null || echo "unknown")
+    echo -e "  ${RED}Killing PID ${PID}${NC} — ${CMD:0:100}"
+    kill "$PID" 2>/dev/null || true
+    COUNT=$((COUNT + 1))
+  fi
+done
+
+# Give processes a moment to terminate gracefully
+sleep 1
+
+# Check for survivors and SIGKILL if needed
+SURVIVORS=""
+for PID in $PIDS; do
+  if kill -0 "$PID" 2>/dev/null; then
+    SURVIVORS="$SURVIVORS $PID"
+  fi
+done
+
+if [[ -n "$SURVIVORS" ]]; then
+  echo -e "${YELLOW}⚠ ${COUNT} processes killed, but some did not terminate gracefully. Forcing SIGKILL...${NC}"
+  for PID in $SURVIVORS; do
+    CMD=$(ps -o args= -p "$PID" 2>/dev/null || echo "unknown")
+    echo -e "  ${RED}Force killing PID ${PID}${NC} — ${CMD:0:100}"
+    kill -9 "$PID" 2>/dev/null || true
+  done
+
+  # Final verification
+  sleep 0.5
+  FINAL=""
+  for PID in $PIDS; do
+    if kill -0 "$PID" 2>/dev/null; then
+      FINAL="$FINAL $PID"
+    fi
+  done
+
+  if [[ -n "$FINAL" ]]; then
+    echo -e "${RED}✖ Failed to kill PIDs:${NC}$FINAL"
+    exit 1
+  fi
+fi
+
+echo ""
+echo -e "${GREEN}✓ Killed ${COUNT} stale Playwright MCP process(es).${NC}"
+echo -e "${GREEN}✓ Clean slate ready for fresh MCP server spawn.${NC}"


### PR DESCRIPTION
## Summary

Adds a utility script to kill all stale Playwright MCP zombie processes that persist after a Cline restart, eliminating the manual ps/grep/kill cycle that wasted ~2 minutes per restart.

## Changes

- **scripts/kill-playwright-mcp.sh** — New utility script that:
  - Uses pgrep to find all playwright-mcp processes
  - Falls back to ps + grep if pgrep is unavailable
  - Sends graceful SIGTERM first, then SIGKILL for survivors
  - Provides color-coded output with PID and command info
  - Returns clean exit codes (0 if all killed, 1 if any survive)

- **Updated .clinerules** — Integrated as step 0 before Playwright MCP troubleshooting:
  - Added Available Utility Scripts section referencing the new script
  - Added stale process cleanup step before Playwright MCP troubleshooting
  - Updated mission log with before/after comparison

## Before vs After

| Before | After |
|--------|-------|
| Manual ps+grep+kill each PID (~2 min/restart) | ./scripts/kill-playwright-mcp.sh (~2 seconds) |
| Forgotten zombies cause MCP conflicts | Clean slate every time |
