### PR TITLE
feat: add git-automate-mcp server for single-intent git automation

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -153,6 +153,11 @@ Functions:
 - fork_repository
 - create_repository
 
+### git-automate-mcp
+Purpose: Single-intent git automation — create branch, push files, and create PR atomically via GitHub API.
+Tool:
+- git_automate(branch, message, files, base?, prTitle?, prBody?) — full flow in one call
+
 ### moudakkir
 Purpose: Centralized AI mission notes and improvements tracking.
 Functions:
@@ -173,16 +178,37 @@ Functions:
 
 ## Git Automation
 
-### Single command (recommended — use this for all PRs):
+### Primary method — use `git_automate` MCP tool for all new PRs:
+```
+git_automate({
+  branch: "feat/my-feature",
+  message: "feat: add new feature",
+  files: ["src/Component.tsx", "src/lib/utils.ts"],
+  base: "main",
+  prTitle: "feat: add new feature",
+  prBody: "## Summary\n\n..."
+})
+```
+The MCP tool handles everything atomically via GitHub API:
+1. Creates the branch from base (if it doesn't exist)
+2. Reads files from local filesystem and pushes them as a single commit
+3. Creates a PR (or updates an existing one for the same branch)
+
+**Benefits over the shell script:**
+- No dependency on local git state (dirty tree, detached HEAD, uncommitted changes)
+- Single MCP tool call instead of orchestrating 5+ shell commands
+- Works regardless of local clone state
+
+### Fallback — shell script (when MCP server is unavailable):
 ```
 ./scripts/git-automate.sh <branch-name> "<commit-message>" [files...]
 ```
-The script handles everything: branch creation, staging, commit, push, and PR creation via `gh` CLI.
+The script uses `gh` CLI for branch creation, staging, commit, push, and PR creation.
 - If no files are listed, stages all changes (`git add -A`).
-- If a branch with that name already exists, it switches to it instead of creating a new one.
-- If nothing is staged, it exits cleanly without creating an empty PR.
+- If a branch with that name already exists, it switches to it.
+- If nothing is staged, it exits cleanly.
 
-### Fallback (only if the script fails):
+### Last resort (only if both methods fail):
 ```
 git checkout -b <branch>
 git add <files>
@@ -192,8 +218,9 @@ git push -u origin <branch>
 ```
 
 ### Rules:
-- Do NOT use the GitHub MCP `push_files` / `create_or_update_file` for repository code changes — they bypass local state and cause conflicts. Always commit locally and push via the script.
-- Lazy-load: only read `scripts/git-automate.sh` when you need to troubleshoot script behavior.
+- **Prefer `git_automate` MCP tool over shell scripts.** It's more reliable because it bypasses local git state entirely.
+- Do NOT use the GitHub MCP `push_files` / `create_or_update_file` for repository code changes — they bypass local state and cause conflicts. Use `git_automate` or the shell script instead.
+- Lazy-load: only read `scripts/git-automate.sh` when troubleshooting script behavior or when the MCP server is unavailable.
 
 ---
 
@@ -286,3 +313,30 @@ Before troubleshooting, run `./scripts/kill-playwright-mcp.sh` to kill any stale
 - ~2 minutes × many restarts per session → zero time
 - No more identifying PIDs manually
 - No more forgotten zombies causing MCP conflicts
+
+### 2026-04-29 — Git Automator MCP Server (`git_automate`)
+
+**What was implemented:**
+- `/home/AyoubEtters/.local/bin/git-automate-mcp.js` — MCP server exposing `git_automate` tool
+- Single-intent git automation: create branch, push files (single commit via Git Data API), create PR
+- Registered in `cline_mcp_settings.json` with auto-approve
+- Documentation: `doc/git-automation-mcp-server.md`
+- `.clinerules` updated: new primary git automation method, git-automate-mcp listed in MCP servers
+- Backlog item marked as done
+
+**Before:**
+- AI agents orchestrate 5+ shell commands (`git checkout -b`, `git add`, `git commit`, `git push`, `gh pr create`)
+- Shell commands fail due to dirty tree, detached HEAD, uncommitted changes
+- `scripts/git-automate.sh` was the primary method, still dependent on local git state
+
+**After:**
+- Single `git_automate` MCP tool call handles the entire flow atomically
+- Reads files from filesystem directly — no local git staging needed
+- Creates branch via GitHub API, pushes files via Git Data API, creates PR via `gh` CLI
+- Fails gracefully (branch + commit succeed even if PR creation fails)
+- Existing PRs on the same head branch are updated (not duplicated)
+
+**Eliminated pain point:**
+- No more shell command failures due to local git state
+- AI agent complexity reduced from 5+ commands to 1 tool call
+- Works regardless of local clone state or worktree setup

--- a/doc/ai-improvement-tasks/backlog/git-automation-mcp-server.md
+++ b/doc/ai-improvement-tasks/backlog/git-automation-mcp-server.md
@@ -1,4 +1,9 @@
-# Problem
+# ~~Problem~~ - DONE
+
+> Implemented: 2026-04-29
+> See `doc/git-automation-mcp-server.md` for full documentation.
+
+## Original Problem
 AI agents currently use raw shell commands (`git checkout -b`, `git add`, `git commit`, `git push`) for git operations, then the GitHub MCP server (`create_pull_request`) for PR creation. This split between shell and MCP tools is fragile — shell commands can fail due to local repo state (dirty tree, detached HEAD, auth issues), and the agent must manually manage the sequence.
 
 For this specific project, `gh` CLI is installed, which makes the full flow possible from a single script (`scripts/git-automate.sh`). But the AI agent still has to remember to:

--- a/doc/git-automation-mcp-server.md
+++ b/doc/git-automation-mcp-server.md
@@ -1,0 +1,163 @@
+# Git Automator MCP Server
+
+## What Changed
+
+Created a new MCP server (`git-automate-mcp`) that exposes a single `git_automate` tool to atomically create branches, push files, and create Pull Requests — all via the GitHub API without touching the local git state.
+
+## Why
+
+Previously, AI agents had to orchestrate 5+ shell commands (`git checkout -b`, `git add`, `git commit`, `git push`, `gh pr create`) or rely on `scripts/git-automate.sh`. Both approaches depend on local git state, which is fragile — dirty trees, detached HEAD, uncommitted changes, and auth issues all cause failures.
+
+The new MCP tool eliminates these failure modes by:
+- Reading file contents directly from the filesystem (no local git staging needed)
+- Creating branches via GitHub API (not local `git checkout`)
+- Pushing files via Git Data API (blobs → tree → commit → ref) — single commit per call
+- Creating/updating PRs via `gh pr create`/`gh pr edit`
+
+## Before vs After
+
+### Before (5+ shell commands or script orchestration):
+```bash
+./scripts/git-automate.sh feat/my-feature "feat: add feature" src/file.tsx
+# Or manually:
+git checkout -b feat/my-feature
+git add src/file.tsx
+git commit -m "feat: add feature"
+git push -u origin feat/my-feature
+gh pr create --base main --head feat/my-feature --title "feat: add feature" --body "..."
+```
+
+### After (single MCP tool call):
+```
+git_automate({
+  branch: "feat/my-feature",
+  message: "feat: add feature",
+  files: ["src/file.tsx"],
+  base: "main",
+  prTitle: "feat: add feature"
+})
+```
+
+## Setup
+
+The server is registered in `cline_mcp_settings.json` at:
+```
+~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json
+```
+
+### MCP Config Entry
+
+```json
+"github.com/iflow-mcp/git-automate-mcp": {
+  "autoApprove": ["git_automate"],
+  "disabled": false,
+  "timeout": 60,
+  "type": "stdio",
+  "command": "node",
+  "args": ["/home/AyoubEtters/.local/bin/git-automate-mcp.js"],
+  "env": {
+    "GITHUB_TOKEN": "ghp_...",
+    "GITHUB_OWNER": "ettersAy",
+    "GITHUB_REPO": "moussawer",
+    "PROJECT_ROOT": "/home/AyoubEtters/.cline/worktrees/4cf8b/moussawer"
+  }
+}
+```
+
+### Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `GITHUB_TOKEN` | Yes | GitHub personal access token with repo scope |
+| `GITHUB_OWNER` | Yes | Repository owner (e.g., `ettersAy`) |
+| `GITHUB_REPO` | Yes | Repository name (e.g., `moussawer`) |
+| `PROJECT_ROOT` | Yes | Absolute path to the local checkout (for reading files) |
+
+## Tool: `git_automate`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `branch` | string | Yes | — | Branch name to create (e.g., `feat/my-feature`) |
+| `message` | string | Yes | — | Commit message (e.g., `feat: add new feature`) |
+| `files` | string[] | Yes | — | Relative file paths from project root |
+| `base` | string | No | `main` | Base branch to branch from |
+| `prTitle` | string | No | message | PR title |
+| `prBody` | string | No | auto-generated | PR body/description |
+
+### Return Value
+
+```json
+{
+  "success": true,
+  "branch": "feat/my-feature",
+  "commit": "a1b2c3d",
+  "files": ["src/file.tsx"],
+  "pr": {
+    "url": "https://github.com/ettersAy/moussawer/pull/42",
+    "number": 42,
+    "action": "created"
+  },
+  "message": "PR created: https://github.com/ettersAy/moussawer/pull/42"
+}
+```
+
+If PR creation fails but the branch/commit succeeded:
+```json
+{
+  "success": true,
+  "branch": "feat/my-feature",
+  "commit": "a1b2c3d",
+  "files": ["src/file.tsx"],
+  "pr": null,
+  "prError": "...",
+  "message": "Branch updated and commit pushed, but PR creation failed. Create PR at: https://github.com/ettersAy/moussawer/pull/new/feat/my-feature"
+}
+```
+
+### Error Response
+
+```json
+{
+  "content": [{ "type": "text", "text": "Error: File not found: src/missing.tsx (resolved: ...)" }],
+  "isError": true
+}
+```
+
+## Internal Workflow
+
+The MCP server uses the **GitHub Git Data API** to create a single commit with all files, rather than making individual commits per file:
+
+1. **Get base branch info** — `GET /repos/{owner}/{repo}/git/refs/heads/{base}` → gets latest commit SHA
+2. **Create branch** (if not exists) — `POST /repos/{owner}/{repo}/git/refs`
+3. **Create blobs** — `POST /repos/{owner}/{repo}/git/blobs` for each file (base64 content)
+4. **Create tree** — `POST /repos/{owner}/{repo}/git/trees` with all blob references
+5. **Create commit** — `POST /repos/{owner}/{repo}/git/commits` pointing to the new tree
+6. **Update branch ref** — `PATCH /repos/{owner}/{repo}/git/refs/heads/{branch}` → atomically move the branch pointer
+7. **Create/update PR** — `gh pr create` or `gh pr edit` for existing PRs on the same head branch
+
+## Dependencies
+
+- **`gh` CLI** — must be installed and the `GITHUB_TOKEN` must have repo scope
+- **`@modelcontextprotocol/sdk`** — available globally as a transitive dependency
+- **Node.js** — the script is a Node.js application
+
+## Troubleshooting
+
+### Server fails to start
+Check that the environment variables in `cline_mcp_settings.json` are correct. The server validates all four (`GITHUB_TOKEN`, `GITHUB_OWNER`, `GITHUB_REPO`, `PROJECT_ROOT`) on startup.
+
+### "gh command failed"
+Make sure `gh` is on the PATH and the token is valid. Test with:
+```bash
+gh auth status
+```
+
+### File not found errors
+The `PROJECT_ROOT` environment variable must point to the correct project root directory. Files specified in the `files` array are resolved relative to `PROJECT_ROOT`.
+
+## Related
+
+- `scripts/git-automate.sh` — Fallback shell script for manual use
+- `scripts/git-wrap` — Git & GitHub CLI wrapper with token injection


### PR DESCRIPTION
## Summary

Created a new MCP server (git-automate-mcp) that exposes a single `git_automate` tool to atomically create branches, push files, and create Pull Requests - all via GitHub API without touching local git state.