### PR TITLE
feat: add reflection docs for git-automation-mcp mission

### DIFF
--- a/doc/ai-improvement-tasks/backlog/mcp-settings-location-documentation.md
+++ b/doc/ai-improvement-tasks/backlog/mcp-settings-location-documentation.md
@@ -1,8 +1,13 @@
 # Problem
-The real Cline MCP settings file location is outside the project directory and undocumented. AI agents waste time editing stale config copies in the project root while the real file under `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/` remains unchanged.
+Two `cline_mcp_settings.json` files exist — one for the VS Code Cline extension and another for the CLI/kanban Cline. AI agents must guess which file to edit, and often waste time editing the wrong one.
+
+- VS Code extension: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`
+- CLI/kanban: `~/.cline/data/settings/cline_mcp_settings.json`
+
+Additionally, the CLI/kanban version does not support the `env` field in MCP config entries — wrappers must be used instead. This is another hidden convention that slows down MCP server setup.
 
 # Improvement Needed
-Document the correct MCP settings file path in `.clinerules` or a dedicated config reference doc.
+Document both config file locations and their differences (supported features, wrapper requirements) in `.clinerules` and a dedicated doc file.
 
 # Expected Result
-Future AI agents find and edit the correct config file on the first attempt instead of discovering it through trial and error.
+Future AI agents should know immediately which config file to edit and how to properly configure an MCP server for each Cline version, without trial and error.

--- a/doc/ai-reflection/git-automation-mcp-server.md
+++ b/doc/ai-reflection/git-automation-mcp-server.md
@@ -1,0 +1,25 @@
+# AI Reflection — Git Automator MCP Server
+
+## Discovery Waste
+
+- **Wrong MCP config file:** Spent ~10min editing the VS Code extension settings file (`~/.config/Code/User/...`) instead of the CLI/kanban one (`~/.cline/data/settings/...`). Both files exist with similar contents but serve different Cline instances.
+- **Global module resolution:** `@modelcontextprotocol/sdk` wasn't at the top-level global `node_modules` — it was nested under `kanban` and `@executeautomation/playwright-mcp-server`. Required installing it globally AND setting `NODE_PATH` in the wrapper. The `npm list -g` output showing it as a "deduped" dependency was misleading.
+- **MCP protocol testing:** First `tools/call` test failed silently because the MCP initialize handshake must precede tool calls. Had to craft the JSON-RPC sequence manually.
+- **Wrapper pattern discovery:** Had to read the github-mcp-wrapper.js to understand the project's MCP wrapper pattern. The `env` field in `cline_mcp_settings.json` is not used by the CLI/kanban version — wrappers set env vars instead.
+
+## Missing `.clinerules` Knowledge
+
+- Should document that **two Cline MCP config files exist** and which one each Cline version uses (VS Code extension vs CLI/kanban).
+- Should document the **wrapper pattern** convention — all MCP servers use wrapper scripts that inject env vars, not the `env` field in settings JSON.
+- Should document that `@modelcontextprotocol/sdk` may need a global install + `NODE_PATH` for standalone MCP scripts.
+
+## Automation Opportunities
+
+- Token is hardcoded in `github-mcp-wrapper.js` — a token leakage risk. Should use env var or a secure vault.
+- MCP server smoke test script: a simple script that sends `initialize` + `tools/list` to verify an MCP server is healthy after config changes.
+- No validation for MCP config syntax before restarting Cline — a config validator script would catch `env`-vs-wrapper mismatches.
+
+## Documented
+
+- `doc/git-automation-mcp-server.md` — full documentation for the new MCP server.
+- PR #68 pushed with all changes, already merged.


### PR DESCRIPTION
## Summary

Reflection outputs from the Git Automator MCP Server mission.

## Changes

- **doc/ai-reflection/git-automation-mcp-server.md** — Reflection notes documenting discovery waste, missing .clinerules knowledge, and automation opportunities
- **doc/ai-improvement-tasks/backlog/mcp-settings-location-documentation.md** — Improvement task documenting the dual MCP config file problem (VS Code vs CLI/kanban)