### PR TITLE
feat: P0 admin users tab features

### DIFF
--- a/doc/ai-improvement-tasks/css-file-convention-index.md
+++ b/doc/ai-improvement-tasks/css-file-convention-index.md
@@ -1,0 +1,8 @@
+# Problem
+CSS is split across 17+ files in `src/styles/` with partially overlapping responsibilities (e.g., `admin.css` vs `tables.css` both contain table-related styles; `tags-badges.css` vs `buttons.css` both contain button-like element styles). There is no index or documented convention for where to place new styles.
+
+# Improvement Needed
+Create a CSS convention index documenting each file's purpose and boundaries. Add a note to `.clinerules` about which CSS file to extend for new admin panel components.
+
+# Expected Result
+Future agents will place new styles in the correct file on the first attempt, reducing style conflicts and duplicate declarations.

--- a/doc/ai-improvement-tasks/document-api-utility-conventions.md
+++ b/doc/ai-improvement-tasks/document-api-utility-conventions.md
@@ -1,0 +1,8 @@
+# Problem
+The `server/utils/http.ts` file contains several reusable utilities (`ok()` with meta support, `pagination()`, `AppError`, `validate()`, `asyncHandler`) that are undocumented. New agents waste time re-implementing pagination logic or discovering meta envelope support through trial and error.
+
+# Improvement Needed
+Document the available HTTP utilities, their signatures, and conventions for API response envelopes (including meta/pagination format) in `.clinerules` or a dedicated architecture doc.
+
+# Expected Result
+Future agents will discover and reuse existing utilities immediately instead of duplicating logic or guessing API response shapes.

--- a/doc/ai-improvement-tasks/resource-include-relationship-documentation.md
+++ b/doc/ai-improvement-tasks/resource-include-relationship-documentation.md
@@ -1,0 +1,8 @@
+# Problem
+The relationship between `includes.ts` (Prisma include definitions), `resources.ts` (serializer functions), and route handlers is implicit. Modifying one often requires coordinated changes in the others, but there is no documentation or index of which resource depends on which include.
+
+# Improvement Needed
+Document the dependency chain: route → include → resource serializer. Add inline comments or a README explaining that expanding a resource serializer field requires updating both the corresponding include object and all callers.
+
+# Expected Result
+Agents will understand the three-layer architecture and make coordinated changes in a single pass instead of discovering broken imports one by one.

--- a/doc/ai-improvement-tasks/resource-type-caller-audit.md
+++ b/doc/ai-improvement-tasks/resource-type-caller-audit.md
@@ -1,0 +1,8 @@
+# Problem
+`resources.ts` exports type-dependent functions (`userResource`, `bookingResource`, etc.) that are imported by multiple route files. Changing a resource function's parameter type (e.g., `PhotographerProfileShape`) silently breaks all callers that pass a different shape. Build errors surface only at compile time.
+
+# Improvement Needed
+Add a script or convention to audit all callers of shared resource functions before modifying their type signatures. This could be a grep-based check or a TypeScript project reference validation.
+
+# Expected Result
+Future agents modifying resource serializers will immediately see all affected callers and can update includes/routes in the same edit session without waiting for compilation failures.

--- a/doc/ai-reflection/admin-users-tab-implementation.md
+++ b/doc/ai-reflection/admin-users-tab-implementation.md
@@ -1,0 +1,35 @@
+# Reflection: Admin Users Tab Implementation (2026-05-02)
+
+## Discovery Bottlenecks
+
+- `userResource` in `resources.ts` shares a type (`PhotographerProfileShape`) with `auth.routes.ts` — changing it broke auth registration flow. Should audit all callers before modifying shared resource types.
+- `pagination()` utility already exists in `server/utils/http.ts` but was discovered late; could have been reused instead of inline pagination in admin route.
+- `includes.ts` has separate `userInclude` with minimal photographer profile select — any expansion of `userResource` fields requires updating both `includes.ts` and `resources.ts` in sync.
+- `StatusBadge.tsx` already supports `DISABLED` tone (`tone-danger`) — no CSS change needed for new status.
+
+## Repeated Searches / Wasted Time
+
+- Searched for `userInclude` location multiple times across routes/ and services/ directories.
+- Searched for `PhotographerProfile` Prisma fields multiple times to verify which fields exist on the model.
+- Checked `auth.routes.ts` only after compilation error — should have grepped for `userResource` callers before changing the type signature.
+
+## Missing Documentation / Rules
+
+- `.clinerules` does not document the shared type dependency between `resources.ts` and `auth.routes.ts`.
+- No documented convention about where to add new admin CSS (admin.css vs tables.css vs dedicated file).
+- The relationship between `includes.ts` (Prisma include objects), `resources.ts` (serializers), and route handlers is undocumented — new agents must reverse-engineer this.
+- No index/registry of existing reusable utilities (`pagination()`, `ok()` meta support, `AppError` patterns).
+
+## Automation Opportunities
+
+- Grepping for all callers of a shared type before modifying it could be automated with a pre-check script.
+- Repeated `tsc --noEmit` compilations during development suggest a watch mode would be faster.
+- Database reset (`db:reset`) runs on every `npm test` — an incremental test mode would speed iteration.
+- Checking which CSS files exist and their purposes required manual directory listing — a project index would help.
+
+## Hidden Conventions
+
+- `userResource` in `resources.ts` uses a manually defined `UserShape` type instead of Prisma-generated types — fragile when schema changes.
+- API response helper `ok(res, data, meta)` accepts optional third param for pagination meta — not documented in the function signature.
+- CSS class naming uses BEM-like patterns but not strict BEM (e.g., `users-toolbar`, `search-wrapper`).
+- All new admin panel features go in `src/pages/admin/` as standalone tab components — good pattern to follow.

--- a/server/routes/admin.routes.ts
+++ b/server/routes/admin.routes.ts
@@ -59,9 +59,44 @@ router.get(
   "/admin/users",
   requireAuth,
   requireRole(Role.ADMIN),
-  asyncHandler(async (_req, res) => {
-    const users = await prisma.user.findMany({ include: userInclude, orderBy: { createdAt: "desc" } });
-    ok(res, users.map(userResource));
+  asyncHandler(async (req, res) => {
+    const search = typeof req.query.search === "string" ? req.query.search : undefined;
+    const role = typeof req.query.role === "string" && Object.values(Role).includes(req.query.role as Role) ? req.query.role as Role : undefined;
+    const status = typeof req.query.status === "string" && Object.values(AccountStatus).includes(req.query.status as AccountStatus) ? req.query.status as AccountStatus : undefined;
+
+    const page = Math.max(Number(req.query.page ?? 1), 1);
+    const limit = Math.min(Math.max(Number(req.query.limit ?? 25), 1), 100);
+    const skip = (page - 1) * limit;
+
+    const sortBy = typeof req.query.sortBy === "string" ? req.query.sortBy : "createdAt";
+    const sortOrder = typeof req.query.sortOrder === "string" && req.query.sortOrder.toLowerCase() === "asc" ? "asc" as const : "desc" as const;
+
+    const allowedSortFields = ["name", "email", "role", "status", "createdAt", "updatedAt"];
+    const orderField = allowedSortFields.includes(sortBy) ? sortBy : "createdAt";
+
+    const where: Prisma.UserWhereInput = {};
+    if (search) {
+      where.OR = [
+        { name: { contains: search } },
+        { email: { contains: search } }
+      ];
+    }
+    if (role) where.role = role;
+    if (status) where.status = status;
+
+    const [total, users] = await Promise.all([
+      prisma.user.count({ where }),
+      prisma.user.findMany({
+        where,
+        include: userInclude,
+        orderBy: { [orderField]: sortOrder },
+        skip,
+        take: limit
+      })
+    ]);
+
+    const totalPages = Math.ceil(total / limit);
+    ok(res, users.map(userResource), { page, limit, total, totalPages });
   })
 );
 
@@ -73,13 +108,45 @@ router.patch(
     const body = validate(
       z.object({
         status: z.nativeEnum(AccountStatus).optional(),
-        role: z.nativeEnum(Role).optional()
+        role: z.nativeEnum(Role).optional(),
+        verified: z.boolean().optional()
       }),
       req.body
     );
-    const user = await prisma.user.update({ where: { id: req.params.id }, data: body, include: userInclude });
-    await audit(req.user!.id, "admin.user_update", "User", user.id, body);
+
+    const { verified, ...userData } = body;
+
+    if (verified !== undefined) {
+      const pp = await prisma.photographerProfile.findUnique({ where: { userId: req.params.id } });
+      if (pp) {
+        await prisma.photographerProfile.update({
+          where: { userId: req.params.id },
+          data: { verified }
+        });
+      }
+    }
+
+    const user = await prisma.user.update({ where: { id: req.params.id }, data: userData, include: userInclude });
+    await audit(req.user!.id, "admin.user_update", "User", user.id, { ...body });
     ok(res, userResource(user));
+  })
+);
+
+router.delete(
+  "/admin/users/:id",
+  requireAuth,
+  requireRole(Role.ADMIN),
+  asyncHandler(async (req, res) => {
+    const targetUser = await prisma.user.findUnique({ where: { id: req.params.id } });
+    if (!targetUser) throw new AppError(404, "NOT_FOUND", "User not found");
+    if (targetUser.role === Role.ADMIN) {
+      const adminCount = await prisma.user.count({ where: { role: Role.ADMIN } });
+      if (adminCount <= 1) throw new AppError(409, "LAST_ADMIN", "Cannot delete the last admin account");
+    }
+
+    await prisma.user.delete({ where: { id: req.params.id } });
+    await audit(req.user!.id, "admin.user_delete", "User", targetUser.id, { name: targetUser.name, email: targetUser.email });
+    noContent(res);
   })
 );
 

--- a/server/routes/includes.ts
+++ b/server/routes/includes.ts
@@ -2,7 +2,12 @@ import type { Prisma } from "@prisma/client";
 
 export const userInclude = {
   clientProfile: true,
-  photographerProfile: { select: { id: true, slug: true } }
+  photographerProfile: {
+    select: {
+      id: true, slug: true, verified: true, isPublished: true,
+      city: true, country: true, startingPrice: true, rating: true
+    }
+  }
 } satisfies Prisma.UserInclude;
 
 export const bookingInclude = {

--- a/server/services/resources.ts
+++ b/server/services/resources.ts
@@ -15,9 +15,14 @@ import type {
   User
 } from "@prisma/client";
 
-type UserShape = Pick<User, "id" | "email" | "name" | "role" | "status" | "avatarUrl" | "createdAt">;
+type PhotographerProfileShape = {
+  id: string; slug: string; verified?: boolean; isPublished?: boolean;
+  city?: string; country?: string; startingPrice?: number; rating?: number;
+};
 
-export function userResource(user: UserShape & { clientProfile?: ClientProfile | null; photographerProfile?: { id: string; slug: string } | null }) {
+type UserShape = Pick<User, "id" | "email" | "name" | "role" | "status" | "avatarUrl" | "createdAt" | "updatedAt">;
+
+export function userResource(user: UserShape & { clientProfile?: ClientProfile | null; photographerProfile?: PhotographerProfileShape | null }) {
   return {
     id: user.id,
     email: user.email,
@@ -35,10 +40,17 @@ export function userResource(user: UserShape & { clientProfile?: ClientProfile |
     photographerProfile: user.photographerProfile
       ? {
           id: user.photographerProfile.id,
-          slug: user.photographerProfile.slug
+          slug: user.photographerProfile.slug,
+          verified: user.photographerProfile.verified ?? false,
+          isPublished: user.photographerProfile.isPublished ?? false,
+          city: user.photographerProfile.city ?? "",
+          country: user.photographerProfile.country ?? "",
+          startingPrice: user.photographerProfile.startingPrice ?? 0,
+          rating: user.photographerProfile.rating != null ? Number(Number(user.photographerProfile.rating).toFixed(1)) : 0
         }
       : null,
-    createdAt: user.createdAt
+    createdAt: user.createdAt,
+    updatedAt: user.updatedAt
   };
 }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -18,8 +18,19 @@ export type User = {
   role: "ADMIN" | "CLIENT" | "PHOTOGRAPHER";
   status: string;
   avatarUrl?: string | null;
-  photographerProfile?: { id: string; slug: string } | null;
+  photographerProfile?: {
+    id: string;
+    slug: string;
+    verified?: boolean;
+    isPublished?: boolean;
+    city?: string;
+    country?: string;
+    startingPrice?: number;
+    rating?: number;
+  } | null;
   clientProfile?: { location?: string | null; bio?: string | null; phone?: string | null } | null;
+  createdAt: string;
+  updatedAt: string;
 };
 
 export type Category = {

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -4,7 +4,7 @@ import {
 import { useEffect, useState } from "react";
 import { useToast } from "../components/shared/Toast";
 import { useAuth } from "../contexts/AuthContext";
-import { api, type Booking, type CaseItem, type PortfolioItem, type User } from "../lib/api";
+import { api, type Booking, type CaseItem, type PortfolioItem } from "../lib/api";
 import { ActivityTab } from "./admin/ActivityTab";
 import { BookingsTab } from "./admin/BookingsTab";
 import { CategoriesTab } from "./admin/CategoriesTab";
@@ -29,7 +29,6 @@ export function AdminPage() {
   const toast = useToast();
   const [activeTab, setActiveTab] = useState<Tab>("overview");
   const [stats, setStats] = useState<AdminStats | null>(null);
-  const [users, setUsers] = useState<User[]>([]);
   const [bookings, setBookings] = useState<Booking[]>([]);
   const [allIncidents, setAllIncidents] = useState<CaseItem[]>([]);
   const [allDisputes, setAllDisputes] = useState<CaseItem[]>([]);
@@ -43,13 +42,10 @@ export function AdminPage() {
     action: string; entity: string; entityId: string; metadata: Record<string, unknown>; createdAt: string;
   };
 
-  useEffect(() => { loadStats(); loadUsers(); loadIncidents(); loadDisputes(); loadActivity(); }, []);
+  useEffect(() => { loadStats(); loadIncidents(); loadDisputes(); loadActivity(); }, []);
 
   async function loadStats() {
     try { const r = await api<AdminStats>("/admin/stats"); setStats(r.data); } catch { /* admin only */ }
-  }
-  async function loadUsers() {
-    try { const r = await api<User[]>("/admin/users"); setUsers(r.data); } catch { /* admin only */ }
   }
   async function loadBookings() {
     const qs = bookingFilter ? `?status=${bookingFilter}` : "";
@@ -69,12 +65,6 @@ export function AdminPage() {
   }
   async function loadActivity() {
     try { const r = await api<ActivityLog[]>("/admin/activity"); setLogs(r.data); } catch { /* admin only */ }
-  }
-
-  async function updateUserStatus(targetUser: User, status: string) {
-    await api(`/admin/users/${targetUser.id}`, { method: "PATCH", body: { status } });
-    toast.success(`User ${status.toLowerCase()}.`);
-    loadUsers();
   }
 
   async function updateIncident(incident: CaseItem, status: string) {
@@ -164,7 +154,7 @@ export function AdminPage() {
       </nav>
 
       {activeTab === "overview" && <OverviewTab stats={stats} />}
-      {activeTab === "users" && <UsersTab users={users} onUpdateStatus={updateUserStatus} />}
+      {activeTab === "users" && <UsersTab />}
       {activeTab === "bookings" && (
         <BookingsTab
           bookings={bookings}

--- a/src/pages/admin/UsersTab.tsx
+++ b/src/pages/admin/UsersTab.tsx
@@ -1,41 +1,557 @@
-import { UserCheck, UserX } from "lucide-react";
+import {
+  ArrowDown, ArrowUp, ArrowUpDown, BadgeCheck, ChevronLeft, ChevronRight,
+  Search, Trash2, UserCheck, UserX, X
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { StatusBadge } from "../../components/StatusBadge";
-import type { User } from "../../lib/api";
+import { ConfirmDialog } from "../../components/shared/ConfirmDialog";
+import { useToast } from "../../components/shared/Toast";
+import { api, shortDate, type User } from "../../lib/api";
 
-export function UsersTab({
-  users,
-  onUpdateStatus
-}: {
-  users: User[];
-  onUpdateStatus: (user: User, status: string) => void;
-}) {
+type SortField = "name" | "email" | "role" | "status" | "createdAt";
+type SortDir = "asc" | "desc";
+
+const ROLE_OPTIONS = ["ALL", "ADMIN", "CLIENT", "PHOTOGRAPHER"] as const;
+const STATUS_OPTIONS = ["ALL", "ACTIVE", "SUSPENDED", "DISABLED"] as const;
+const PAGE_SIZES = [10, 25, 50, 100];
+
+function getInitials(name: string): string {
+  return name
+    .split(" ")
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+function AvatarThumb({ user }: { user: User }) {
+  if (user.avatarUrl) {
+    return <img src={user.avatarUrl} alt="" className="user-avatar-thumb" />;
+  }
+  return <span className="user-avatar-fallback">{getInitials(user.name)}</span>;
+}
+
+export function UsersTab() {
+  const toast = useToast();
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [meta, setMeta] = useState({ page: 1, limit: 25, total: 0, totalPages: 0 });
+
+  // Filters
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [roleFilter, setRoleFilter] = useState<string>("ALL");
+  const [statusFilter, setStatusFilter] = useState<string>("ALL");
+
+  // Sorting
+  const [sortField, setSortField] = useState<SortField>("createdAt");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  // Bulk selection
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  // Expandable rows
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  // Confirm dialogs
+  const [confirmDelete, setConfirmDelete] = useState<User | null>(null);
+  const [confirmRole, setConfirmRole] = useState<{ user: User; role: string } | null>(null);
+  const [confirmDisable, setConfirmDisable] = useState<User | null>(null);
+  const [confirmBulk, setConfirmBulk] = useState<{ action: string; ids: string[] } | null>(null);
+
+  // Debounce search
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  // Reset to page 1 when filters change
+  useEffect(() => {
+    setMeta((m) => ({ ...m, page: 1 }));
+  }, [debouncedSearch, roleFilter, statusFilter, sortField, sortDir]);
+
+  // Load users
+  const loadUsers = useCallback(async (pageOverride?: number) => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams();
+      const p = pageOverride ?? meta.page;
+      params.set("page", String(p));
+      params.set("limit", String(meta.limit));
+      params.set("sortBy", sortField);
+      params.set("sortOrder", sortDir);
+      if (debouncedSearch) params.set("search", debouncedSearch);
+      if (roleFilter !== "ALL") params.set("role", roleFilter);
+      if (statusFilter !== "ALL") params.set("status", statusFilter);
+
+      const res = await api<User[]>(`/admin/users?${params.toString()}`);
+      setUsers(res.data);
+      if (res.meta) setMeta(res.meta as typeof meta);
+    } catch {
+      toast.error("Failed to load users");
+    } finally {
+      setLoading(false);
+    }
+  }, [debouncedSearch, roleFilter, statusFilter, sortField, sortDir, meta.limit, toast]);
+
+  useEffect(() => {
+    loadUsers();
+  }, [loadUsers]);
+
+  // Reset selection on data load
+  useEffect(() => {
+    setSelectedIds(new Set());
+  }, [users]);
+
+  // Toggle sort
+  function toggleSort(field: SortField) {
+    if (sortField === field) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortField(field);
+      setSortDir("asc");
+    }
+  }
+
+  function SortIcon({ field }: { field: SortField }) {
+    if (sortField !== field) return <ArrowUpDown size={12} className="sort-icon" />;
+    return sortDir === "asc" ? <ArrowUp size={12} className="sort-icon active" /> : <ArrowDown size={12} className="sort-icon active" />;
+  }
+
+  // Status actions
+  async function updateStatus(user: User, newStatus: string) {
+    try {
+      await api(`/admin/users/${user.id}`, { method: "PATCH", body: { status: newStatus } });
+      toast.success(`User ${newStatus.toLowerCase()}.`);
+      loadUsers();
+    } catch { toast.error("Failed to update status"); }
+  }
+
+  // Role change
+  async function changeRole(user: User, newRole: string) {
+    try {
+      await api(`/admin/users/${user.id}`, { method: "PATCH", body: { role: newRole } });
+      toast.success(`User role changed to ${newRole.toLowerCase()}.`);
+      loadUsers();
+    } catch { toast.error("Failed to update role"); }
+    setConfirmRole(null);
+  }
+
+  // Verification toggle
+  async function toggleVerified(user: User) {
+    if (!user.photographerProfile) return;
+    const newVal = !user.photographerProfile.verified;
+    try {
+      await api(`/admin/users/${user.id}`, { method: "PATCH", body: { verified: newVal } });
+      toast.success(newVal ? "Photographer verified." : "Verification removed.");
+      loadUsers();
+    } catch { toast.error("Failed to update verification status"); }
+  }
+
+  // Delete user
+  async function deleteUser(user: User) {
+    try {
+      await api(`/admin/users/${user.id}`, { method: "DELETE" });
+      toast.success(`User "${user.name}" deleted.`);
+      loadUsers();
+    } catch (err: any) {
+      toast.error(err.message || "Failed to delete user");
+    }
+    setConfirmDelete(null);
+  }
+
+  // Bulk actions
+  async function executeBulk(action: string, ids: string[]) {
+    try {
+      if (action === "delete") {
+        await Promise.all(ids.map((id) => api(`/admin/users/${id}`, { method: "DELETE" })));
+        toast.success(`${ids.length} user(s) deleted.`);
+      } else if (action === "activate") {
+        await Promise.all(ids.map((id) => api(`/admin/users/${id}`, { method: "PATCH", body: { status: "ACTIVE" } })));
+        toast.success(`${ids.length} user(s) activated.`);
+      } else if (action === "suspend") {
+        await Promise.all(ids.map((id) => api(`/admin/users/${id}`, { method: "PATCH", body: { status: "SUSPENDED" } })));
+        toast.success(`${ids.length} user(s) suspended.`);
+      }
+      loadUsers();
+    } catch { toast.error("Bulk action failed."); }
+    setConfirmBulk(null);
+  }
+
+  function toggleSelect(id: string) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleSelectAll() {
+    if (selectedIds.size === users.length) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(users.map((u) => u.id)));
+    }
+  }
+
+  const allSelected = users.length > 0 && selectedIds.size === users.length;
+
+  // Pagination controls
+  const pages = useMemo(() => {
+    const arr: number[] = [];
+    const tp = meta.totalPages;
+    const cp = meta.page;
+    if (tp <= 7) {
+      for (let i = 1; i <= tp; i++) arr.push(i);
+    } else {
+      arr.push(1);
+      if (cp > 3) arr.push(-1);
+      const start = Math.max(2, cp - 1);
+      const end = Math.min(tp - 1, cp + 1);
+      for (let i = start; i <= end; i++) arr.push(i);
+      if (cp < tp - 2) arr.push(-1);
+      arr.push(tp);
+    }
+    return arr;
+  }, [meta.totalPages, meta.page]);
+
+  function getActionButtons(user: User) {
+    const buttons: { label: string; icon: React.ReactNode; onClick: () => void; className?: string }[] = [];
+
+    if (user.status === "ACTIVE") {
+      buttons.push({ label: "Suspend", icon: <UserX size={14} />, onClick: () => updateStatus(user, "SUSPENDED") });
+      buttons.push({ label: "Disable", icon: <X size={14} />, onClick: () => setConfirmDisable(user), className: "danger" });
+    } else if (user.status === "SUSPENDED") {
+      buttons.push({ label: "Activate", icon: <UserCheck size={14} />, onClick: () => updateStatus(user, "ACTIVE") });
+      buttons.push({ label: "Disable", icon: <X size={14} />, onClick: () => setConfirmDisable(user), className: "danger" });
+    } else {
+      buttons.push({ label: "Activate", icon: <UserCheck size={14} />, onClick: () => updateStatus(user, "ACTIVE") });
+    }
+
+    return buttons;
+  }
+
   return (
     <div className="admin-section">
       <section className="panel">
-        <h2>All users ({users.length})</h2>
-        <div className="table-list">
-          {users.map((u) => (
-            <div className="table-row" key={u.id}>
-              <div>
-                <strong>{u.name}</strong>
-                <p>{u.email} · {u.role.toLowerCase()}</p>
-              </div>
-              <StatusBadge value={u.status} />
-              <div className="inline-actions">
-                {u.status === "ACTIVE" ? (
-                  <button className="ghost-button compact" onClick={() => onUpdateStatus(u, "SUSPENDED")}>
-                    <UserX size={15} /> Suspend
-                  </button>
-                ) : (
-                  <button className="ghost-button compact" onClick={() => onUpdateStatus(u, "ACTIVE")}>
-                    <UserCheck size={15} /> Activate
-                  </button>
-                )}
-              </div>
-            </div>
-          ))}
+        <h2>Manage Users {!loading && <span className="count-badge">{meta.total}</span>}</h2>
+
+        {/* Toolbar: Search + Filters */}
+        <div className="users-toolbar">
+          <div className="search-wrapper">
+            <Search size={16} className="search-icon" />
+            <input
+              ref={searchRef}
+              type="text"
+              placeholder="Search by name or email…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="search-input"
+            />
+            {search && (
+              <button className="search-clear" onClick={() => { setSearch(""); searchRef.current?.focus(); }} aria-label="Clear search">
+                <X size={14} />
+              </button>
+            )}
+          </div>
+          <select value={roleFilter} onChange={(e) => setRoleFilter(e.target.value)} className="filter-select">
+            {ROLE_OPTIONS.map((r) => <option key={r} value={r}>{r === "ALL" ? "All Roles" : r.toLowerCase()}</option>)}
+          </select>
+          <select value={statusFilter} onChange={(e) => setStatusFilter(e.target.value)} className="filter-select">
+            {STATUS_OPTIONS.map((s) => <option key={s} value={s}>{s === "ALL" ? "All Statuses" : s.toLowerCase()}</option>)}
+          </select>
+          <select value={String(meta.limit)} onChange={(e) => setMeta((m) => ({ ...m, limit: Number(e.target.value), page: 1 }))} className="filter-select page-size-select">
+            {PAGE_SIZES.map((s) => <option key={s} value={s}>{s} per page</option>)}
+          </select>
         </div>
+
+        {/* Bulk action bar */}
+        {selectedIds.size > 0 && (
+          <div className="bulk-bar">
+            <span className="bulk-count">{selectedIds.size} selected</span>
+            <button className="ghost-button compact" onClick={() => setConfirmBulk({ action: "activate", ids: Array.from(selectedIds) })}>
+              <UserCheck size={14} /> Activate all
+            </button>
+            <button className="ghost-button compact" onClick={() => setConfirmBulk({ action: "suspend", ids: Array.from(selectedIds) })}>
+              <UserX size={14} /> Suspend all
+            </button>
+            <button className="ghost-button compact danger" onClick={() => setConfirmBulk({ action: "delete", ids: Array.from(selectedIds) })}>
+              <Trash2 size={14} /> Delete all
+            </button>
+          </div>
+        )}
+
+        {/* Table */}
+        {loading ? (
+          <div className="loading-state">Loading users…</div>
+        ) : users.length === 0 ? (
+          <div className="empty-state">No users found.</div>
+        ) : (
+          <div className="users-table-wrapper">
+            <table className="users-table">
+              <thead>
+                <tr>
+                  <th className="col-check">
+                    <input type="checkbox" checked={allSelected} onChange={toggleSelectAll} aria-label="Select all users" />
+                  </th>
+                  <th className="col-avatar"></th>
+                  <th className="col-sortable" onClick={() => toggleSort("name")}>
+                    Name <SortIcon field="name" />
+                  </th>
+                  <th className="col-sortable" onClick={() => toggleSort("email")}>
+                    Email <SortIcon field="email" />
+                  </th>
+                  <th className="col-sortable" onClick={() => toggleSort("role")}>
+                    Role <SortIcon field="role" />
+                  </th>
+                  <th className="col-sortable" onClick={() => toggleSort("status")}>
+                    Status <SortIcon field="status" />
+                  </th>
+                  <th className="col-sortable" onClick={() => toggleSort("createdAt")}>
+                    Joined <SortIcon field="createdAt" />
+                  </th>
+                  <th className="col-actions">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((user) => (
+                  <UserRow
+                    key={user.id}
+                    user={user}
+                    isSelected={selectedIds.has(user.id)}
+                    isExpanded={expandedId === user.id}
+                    onToggleSelect={() => toggleSelect(user.id)}
+                    onToggleExpand={() => setExpandedId(expandedId === user.id ? null : user.id)}
+                    actionButtons={getActionButtons(user)}
+                    onRoleChange={(role) => setConfirmRole({ user, role })}
+                    onToggleVerified={toggleVerified}
+                    onDelete={() => setConfirmDelete(user)}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Pagination */}
+        {meta.totalPages > 1 && (
+          <div className="pagination">
+            <button
+              className="icon-button compact"
+              disabled={meta.page <= 1}
+              onClick={() => loadUsers(meta.page - 1)}
+              aria-label="Previous page"
+            >
+              <ChevronLeft size={14} />
+            </button>
+            {pages.map((p, i) =>
+              p === -1 ? (
+                <span key={`ellipsis-${i}`} className="page-ellipsis">…</span>
+              ) : (
+                <button
+                  key={p}
+                  className={`page-btn ${meta.page === p ? "active" : ""}`}
+                  onClick={() => loadUsers(p)}
+                >
+                  {p}
+                </button>
+              )
+            )}
+            <button
+              className="icon-button compact"
+              disabled={meta.page >= meta.totalPages}
+              onClick={() => loadUsers(meta.page + 1)}
+              aria-label="Next page"
+            >
+              <ChevronRight size={14} />
+            </button>
+            <span className="page-info">
+              {meta.total} user{meta.total !== 1 ? "s" : ""}
+            </span>
+          </div>
+        )}
       </section>
+
+      {/* Confirm dialogs */}
+      <ConfirmDialog
+        open={confirmDelete !== null}
+        title="Delete user?"
+        message={`Are you sure you want to permanently delete "${confirmDelete?.name}" (${confirmDelete?.email})? This will cascade delete all associated data including bookings, messages, and profile information. This action cannot be undone.`}
+        confirmLabel="Delete permanently"
+        variant="danger"
+        onConfirm={() => confirmDelete && deleteUser(confirmDelete)}
+        onCancel={() => setConfirmDelete(null)}
+      />
+      <ConfirmDialog
+        open={confirmDisable !== null}
+        title="Disable account?"
+        message={`Disable "${confirmDisable?.name}"? They will not be able to log in or use the platform. This can be reversed by setting the account back to ACTIVE.`}
+        confirmLabel="Disable account"
+        variant="danger"
+        onConfirm={() => { if (confirmDisable) { updateStatus(confirmDisable, "DISABLED"); setConfirmDisable(null); } }}
+        onCancel={() => setConfirmDisable(null)}
+      />
+      <ConfirmDialog
+        open={confirmRole !== null}
+        title="Change user role?"
+        message={`Change "${confirmRole?.user.name}"'s role from ${confirmRole?.user.role.toLowerCase()} to ${confirmRole?.role.toLowerCase()}? This may affect their platform access and capabilities.`}
+        confirmLabel="Change role"
+        variant="warning"
+        onConfirm={() => confirmRole && changeRole(confirmRole.user, confirmRole.role)}
+        onCancel={() => setConfirmRole(null)}
+      />
+      <ConfirmDialog
+        open={confirmBulk !== null}
+        title={`Bulk ${confirmBulk?.action}?`}
+        message={`This will ${confirmBulk?.action} ${confirmBulk?.ids.length} user account(s). Are you sure?`}
+        confirmLabel={`${confirmBulk?.action} ${confirmBulk?.ids.length} user(s)`}
+        variant={confirmBulk?.action === "delete" ? "danger" : "warning"}
+        onConfirm={() => confirmBulk && executeBulk(confirmBulk.action, confirmBulk.ids)}
+        onCancel={() => setConfirmBulk(null)}
+      />
+    </div>
+  );
+}
+
+function UserRow({
+  user, isSelected, isExpanded, onToggleSelect, onToggleExpand,
+  actionButtons, onRoleChange, onToggleVerified, onDelete
+}: {
+  user: User;
+  isSelected: boolean;
+  isExpanded: boolean;
+  onToggleSelect: () => void;
+  onToggleExpand: () => void;
+  actionButtons: { label: string; icon: React.ReactNode; onClick: () => void; className?: string }[];
+  onRoleChange: (role: string) => void;
+  onToggleVerified: (user: User) => void;
+  onDelete: () => void;
+}) {
+  const isPhotographer = user.role === "PHOTOGRAPHER";
+  const pp = user.photographerProfile;
+
+  return (
+    <>
+      <tr className={`user-row ${isExpanded ? "expanded" : ""}`}>
+        <td className="col-check">
+          <input type="checkbox" checked={isSelected} onChange={onToggleSelect} aria-label={`Select ${user.name}`} />
+        </td>
+        <td className="col-avatar" onClick={onToggleExpand}>
+          <AvatarThumb user={user} />
+        </td>
+        <td className="col-name" onClick={onToggleExpand}>
+          <span className="user-name">{user.name}</span>
+        </td>
+        <td className="col-email">{user.email}</td>
+        <td className="col-role">
+          <select
+            value={user.role}
+            onChange={(e) => onRoleChange(e.target.value)}
+            className="role-select"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <option value="CLIENT">Client</option>
+            <option value="PHOTOGRAPHER">Photographer</option>
+            <option value="ADMIN">Admin</option>
+          </select>
+        </td>
+        <td className="col-status">
+          <StatusBadge value={user.status} />
+        </td>
+        <td className="col-joined">{shortDate(user.createdAt)}</td>
+        <td className="col-actions">
+          <div className="user-actions">
+            {isPhotographer && (
+              <button
+                className={`icon-button compact ${pp?.verified ? "verified-badge" : ""}`}
+                onClick={() => onToggleVerified(user)}
+                title={pp?.verified ? "Verified — click to unverify" : "Not verified — click to verify"}
+              >
+                <BadgeCheck size={14} className={pp?.verified ? "verified-icon" : "unverified-icon"} />
+              </button>
+            )}
+            {actionButtons.map((btn, i) => (
+              <button
+                key={i}
+                className={`ghost-button compact ${btn.className ?? ""}`}
+                onClick={btn.onClick}
+                title={btn.label}
+              >
+                {btn.icon}{btn.label}
+              </button>
+            ))}
+            <button className="ghost-button compact danger" onClick={onDelete} title="Delete user">
+              <Trash2 size={14} />
+            </button>
+          </div>
+        </td>
+      </tr>
+      {isExpanded && (
+        <tr className="user-detail-row">
+          <td colSpan={8}>
+            <UserDetail user={user} />
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+function UserDetail({ user }: { user: User }) {
+  const pp = user.photographerProfile;
+  const cp = user.clientProfile;
+
+  return (
+    <div className="user-detail">
+      <div className="detail-header">
+        <AvatarThumb user={user} />
+        <div>
+          <strong className="detail-name">{user.name}</strong>
+          <span className="detail-email">{user.email}</span>
+          <div className="detail-meta-row">
+            <StatusBadge value={user.status} />
+            <span className="detail-role-tag">{user.role.toLowerCase()}</span>
+            {pp?.verified && <span className="detail-verified">✓ Verified photographer</span>}
+          </div>
+        </div>
+      </div>
+      <div className="detail-grid">
+        <div className="detail-section">
+          <h4>Account Info</h4>
+          <dl>
+            <dt>User ID</dt><dd><code>{user.id}</code></dd>
+            <dt>Joined</dt><dd>{shortDate(user.createdAt)}</dd>
+            <dt>Last updated</dt><dd>{shortDate(user.updatedAt)}</dd>
+          </dl>
+        </div>
+        {cp && (
+          <div className="detail-section">
+            <h4>Client Profile</h4>
+            <dl>
+              {cp.location && <><dt>Location</dt><dd>{cp.location}</dd></>}
+              {cp.bio && <><dt>Bio</dt><dd>{cp.bio}</dd></>}
+              {cp.phone && <><dt>Phone</dt><dd>{cp.phone}</dd></>}
+            </dl>
+          </div>
+        )}
+        {pp && (
+          <div className="detail-section">
+            <h4>Photographer Profile</h4>
+            <dl>
+              <dt>Slug</dt><dd><code>{pp.slug}</code></dd>
+              <dt>City</dt><dd>{pp.city}</dd>
+              <dt>Country</dt><dd>{pp.country}</dd>
+              <dt>Starting price</dt><dd>${pp.startingPrice}</dd>
+              <dt>Rating</dt><dd>{pp.rating} / 5</dd>
+              <dt>Published</dt><dd>{pp.isPublished ? "Yes" : "No"}</dd>
+              <dt>Verified</dt><dd>{pp.verified ? "Yes" : "No"}</dd>
+            </dl>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -82,3 +82,414 @@
   font-size: 0.95rem;
   margin-bottom: 4px;
 }
+
+/* Users table styles */
+.count-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  height: 24px;
+  border-radius: 12px;
+  background: var(--wash);
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 700;
+  padding: 0 6px;
+  vertical-align: middle;
+  margin-left: 8px;
+}
+
+.users-toolbar {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.search-wrapper {
+  position: relative;
+  flex: 1;
+  min-width: 200px;
+}
+
+.search-icon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--muted);
+  pointer-events: none;
+}
+
+.search-input {
+  padding-left: 36px;
+  padding-right: 32px;
+  min-height: 38px;
+}
+
+.search-clear {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--muted);
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.search-clear:hover {
+  background: var(--wash);
+  color: var(--ink);
+}
+
+.filter-select {
+  min-width: 140px;
+  min-height: 38px;
+  width: auto;
+}
+
+.page-size-select {
+  min-width: 120px;
+}
+
+.bulk-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  background: var(--blue-soft);
+  border-radius: 8px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.bulk-count {
+  font-weight: 700;
+  font-size: 0.88rem;
+  color: var(--blue);
+  margin-right: 8px;
+}
+
+.loading-state,
+.empty-state {
+  text-align: center;
+  padding: 48px 24px;
+  color: var(--muted);
+}
+
+.users-table-wrapper {
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+
+.users-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+}
+
+.users-table thead {
+  background: var(--wash);
+  border-bottom: 1px solid var(--line);
+}
+
+.users-table th {
+  padding: 10px 12px;
+  text-align: left;
+  font-weight: 700;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  white-space: nowrap;
+  user-select: none;
+}
+
+.users-table th.col-sortable {
+  cursor: pointer;
+}
+
+.users-table th.col-sortable:hover {
+  color: var(--ink);
+}
+
+.sort-icon {
+  vertical-align: middle;
+  margin-left: 4px;
+  opacity: 0.3;
+}
+
+.sort-icon.active {
+  opacity: 1;
+  color: var(--blue);
+}
+
+.users-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--line);
+  vertical-align: middle;
+}
+
+.users-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.user-row {
+  transition: background 0.1s;
+}
+
+.user-row:hover {
+  background: var(--wash);
+}
+
+.user-row.expanded {
+  background: var(--wash);
+}
+
+.col-check {
+  width: 36px;
+  text-align: center;
+}
+
+.col-check input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  min-height: auto;
+}
+
+.col-avatar {
+  width: 44px;
+  cursor: pointer;
+}
+
+.col-name {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.col-joined {
+  white-space: nowrap;
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.col-actions {
+  text-align: right;
+}
+
+.user-avatar-thumb {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+  background: var(--wash);
+}
+
+.user-avatar-fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--blue-soft);
+  color: var(--blue);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.user-actions {
+  display: flex;
+  gap: 4px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.role-select {
+  min-height: 30px;
+  width: auto;
+  padding: 4px 8px;
+  font-size: 0.82rem;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.verified-icon {
+  color: var(--green);
+}
+
+.unverified-icon {
+  color: var(--muted);
+}
+
+.verified-badge {
+  border-color: var(--green) !important;
+}
+
+.danger {
+  color: var(--red) !important;
+  border-color: var(--red-soft) !important;
+}
+
+.danger:hover {
+  background: var(--red-soft) !important;
+}
+
+/* Pagination */
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 20px;
+  flex-wrap: wrap;
+}
+
+.page-btn {
+  min-width: 34px;
+  height: 34px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--paper);
+  color: var(--ink);
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.12s, border-color 0.12s;
+}
+
+.page-btn:hover {
+  background: var(--wash);
+  border-color: var(--muted);
+}
+
+.page-btn.active {
+  background: var(--blue);
+  color: #fff;
+  border-color: var(--blue);
+}
+
+.page-ellipsis {
+  padding: 0 4px;
+  color: var(--muted);
+}
+
+.page-info {
+  margin-left: 12px;
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+/* User detail row */
+.user-detail-row td {
+  padding: 0;
+  background: var(--wash);
+}
+
+.user-detail {
+  padding: 20px 24px;
+  border-top: 2px solid var(--blue-soft);
+}
+
+.detail-header {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  margin-bottom: 20px;
+}
+
+.detail-header .user-avatar-thumb,
+.detail-header .user-avatar-fallback {
+  width: 48px;
+  height: 48px;
+  font-size: 1rem;
+}
+
+.detail-name {
+  display: block;
+  font-size: 1.1rem;
+  margin-bottom: 2px;
+}
+
+.detail-email {
+  display: block;
+  color: var(--muted);
+  font-size: 0.88rem;
+  margin-bottom: 6px;
+}
+
+.detail-meta-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.detail-role-tag {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+
+.detail-verified {
+  font-size: 0.78rem;
+  color: var(--green);
+  font-weight: 600;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 20px;
+}
+
+.detail-section h4 {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  margin-bottom: 10px;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 6px;
+}
+
+.detail-section dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 12px;
+  font-size: 0.85rem;
+}
+
+.detail-section dt {
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.detail-section dd {
+  margin: 0;
+  word-break: break-all;
+}
+
+.detail-section code {
+  font-size: 0.75rem;
+  background: var(--paper);
+  padding: 2px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--line);
+}


### PR DESCRIPTION
Implements all P0 features from the Admin Users Tab audit/backlog:

### Backend
- **GET /admin/users**: Added 
Usage:

    To search for something simply use 'search for':

        search for [keyword]

    You can restrict the search to a particular path by adding 'in [path]':

        search for [keyword] in [path]

    The following options are also supported:

        -c | --case-sensitive
        -s | --show-filenames-only

    Examples:

        search for keyword in ./

        search in ../ for Keyword --case-sensitive

        search -s in ../ for keyword, , , , , ,  query params with pagination meta envelope
- **DELETE /admin/users/:id**: New endpoint with last-admin protection
- **PATCH /admin/users/:id**: Added  flag support for photographer profiles
- **userResource**: Expanded serializer with photographer profile fields (verified, isPublished, city, country, startingPrice, rating, updatedAt)

### Frontend (UsersTab.tsx)
- **Search & Filter**: Debounced search by name/email, role + status dropdown filters
- **Pagination**: Page number buttons, prev/next, page size selector (10/25/50/100)
- **Sortable Columns**: Clickable headers with sort direction indicators
- **User Detail Row**: Click to expand showing full user profile (account info, client profile, photographer profile)
- **Role Management**: Inline role dropdown with confirmation dialog
- **DISABLED Status**: Full support with disable action + confirmation
- **User Deletion**: Delete button with cascading data warning
- **Bulk Actions**: Checkbox selection + Select All, bulk activate/suspend/delete
- **Photographer Verification**: Toggle badge with visual indicator
- **Avatar Thumbnails**: Circular avatars with initials fallback

### Also
- Cleaned up AdminPage.tsx by delegating user state management to UsersTab
- Added reflection docs and improvement tasks