### PR TITLE
feat: admin user create/edit for any role (admin, client, photographer)

### DIFF
--- a/doc/ai-improvement-tasks/mcp-server-connection-reliability.md
+++ b/doc/ai-improvement-tasks/mcp-server-connection-reliability.md
@@ -1,0 +1,14 @@
+# Problem
+The `moussawer-mcp` MCP server failed with `MCP error -32000: Connection closed` on first invocation. No fallback or retry mechanism exists when an MCP server fails to connect. The error provides no diagnostic information about why the connection closed (port conflict, unhandled exception, missing dependency, startup timeout).
+
+# Improvement Needed
+Implement connection reliability improvements for custom MCP servers:
+1. Add startup timeout detection and retry logic.
+2. Surface server startup logs (stderr/stdout) in the error message instead of a generic "Connection closed".
+3. Add a health-check endpoint or startup probe that the MCP client can verify before marking the server as ready.
+
+# Expected Result
+Future AI agents should either:
+- Get a detailed error message explaining why the MCP server failed to start (port in use? missing module? crash loop?).
+- Or have a retry mechanism that allows transient failures to self-recover.
+- Or have clear instructions in `.clinerules` on what to check when a specific MCP server (like moussawer-mcp) fails to connect.

--- a/doc/ai-reflection/admin-user-create-edit-implementation.md
+++ b/doc/ai-reflection/admin-user-create-edit-implementation.md
@@ -1,0 +1,31 @@
+# Reflection: Admin User Create/Edit Implementation (2026-05-02)
+
+## Discovery Bottlenecks
+
+- Input size limits on `editor` tool caused file creation to fail – had to split `UserFormModal.tsx` into 3 separate `edit_file` calls. Should use `write_file` for new files regardless of size.
+- `Prisma.ClientProfileCreateInput` requires a `user` relation type but passing `userId` scalar works at runtime – TypeScript strict checking forced `as any` cast. Not obvious from Prisma types.
+- Had to re-read auth.routes.ts to understand registration patterns (password hashing, profile creation) – a quick reference doc for common backend patterns would save time.
+
+## Repeated Searches / Wasted Time
+
+- Searched for `bcrypt` import location multiple times — not obvious that `auth.routes.ts` uses it but `admin.routes.ts` also needs it.
+- Checked `schema.prisma` multiple times to verify `ClientProfile` and `PhotographerProfile` field names.
+- Re-checked `userResource` return shape in `resources.ts` to ensure the existing `User` type in `api.ts` was compatible with the new form's data extraction.
+
+## Missing Documentation / Rules
+
+- No documented pattern for adding new admin API endpoints that create/update related models (e.g., creating User + profile in one request).
+- The `uniqueSlug()` helper in `helpers.ts` was discovered by scanning imports – should be listed in `.clinerules` utilities section.
+- No documentation about the Zod validation patterns used across route files – had to reverse-engineer from existing routes.
+
+## Automation Opportunities
+
+- Creating a new React component with form boilerplate could be semi-automated with a code generator.
+- Repeated `Prisma` type assertion issues (`as any`) suggest a need for a documented pattern on how to handle scalar-only creates without relation types.
+- The `editor` tool's 6000-char limit causes timeouts on medium files — a file-size checker before operation could prevent mid-edit failures.
+
+## Hidden Conventions
+
+- Admin route validation uses `z.nativeEnum()` for enums (Role, AccountStatus) — consistent pattern across all admin routes.
+- The `bio` field is shared between ClientProfile and PhotographerProfile in the form but maps to different Prisma models depending on role.
+- Modal components follow a consistent pattern: `open` prop, close on overlay click, `onClose`/`onConfirm` callbacks.

--- a/server/routes/admin.routes.ts
+++ b/server/routes/admin.routes.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import bcrypt from "bcryptjs";
 import {
   AccountStatus, BookingStatus, DisputeStatus, IncidentStatus, Role
 } from "@prisma/client";
@@ -9,7 +10,7 @@ import { requireAuth, requireRole } from "../middleware/auth";
 import { audit } from "../services/notifications";
 import { bookingResource, userResource } from "../services/resources";
 import { AppError, asyncHandler, created, noContent, ok, validate } from "../utils/http";
-import { slugify } from "./helpers";
+import { slugify, uniqueSlug } from "./helpers";
 import { bookingInclude, userInclude } from "./includes";
 
 export const router = Router();
@@ -100,6 +101,74 @@ router.get(
   })
 );
 
+router.post(
+  "/admin/users",
+  requireAuth,
+  requireRole(Role.ADMIN),
+  asyncHandler(async (req, res) => {
+    const body = validate(
+      z.object({
+        name: z.string().min(2),
+        email: z.string().email(),
+        password: z.string().min(6),
+        role: z.nativeEnum(Role),
+        avatarUrl: z.string().url().optional().nullable(),
+        // Client profile fields
+        location: z.string().optional().nullable(),
+        bio: z.string().optional().nullable(),
+        phone: z.string().optional().nullable(),
+        // Photographer profile fields
+        city: z.string().optional(),
+        startingPrice: z.number().int().positive().optional()
+      }),
+      req.body
+    );
+
+    const email = body.email.toLowerCase();
+    const existing = await prisma.user.findUnique({ where: { email } });
+    if (existing) throw new AppError(409, "EMAIL_EXISTS", "An account with this email already exists");
+
+    const passwordHash = await bcrypt.hash(body.password, 12);
+
+    const user = await prisma.user.create({
+      data: {
+        email,
+        passwordHash,
+        name: body.name,
+        role: body.role,
+        avatarUrl: body.avatarUrl ?? undefined,
+        clientProfile:
+          body.role === Role.CLIENT
+            ? {
+                create: {
+                  location: body.location ?? undefined,
+                  bio: body.bio ?? undefined,
+                  phone: body.phone ?? undefined
+                }
+              }
+            : undefined,
+        photographerProfile:
+          body.role === Role.PHOTOGRAPHER
+            ? {
+                create: {
+                  slug: await uniqueSlug(body.name),
+                  bio: body.bio ?? "Available for curated photography sessions.",
+                  city: body.city ?? "Toronto",
+                  startingPrice: body.startingPrice ?? 250
+                }
+              }
+            : undefined
+      },
+      include: userInclude
+    });
+
+    await audit(req.user!.id, "admin.user_create", "User", user.id, {
+      name: body.name, email: body.email, role: body.role
+    });
+    created(res, userResource(user));
+  })
+);
+
 router.patch(
   "/admin/users/:id",
   requireAuth,
@@ -107,26 +176,88 @@ router.patch(
   asyncHandler(async (req, res) => {
     const body = validate(
       z.object({
+        name: z.string().min(2).optional(),
+        email: z.string().email().optional(),
+        avatarUrl: z.string().url().optional().nullable(),
         status: z.nativeEnum(AccountStatus).optional(),
         role: z.nativeEnum(Role).optional(),
-        verified: z.boolean().optional()
+        verified: z.boolean().optional(),
+        // Client profile fields
+        location: z.string().optional().nullable(),
+        bio: z.string().optional().nullable(),
+        phone: z.string().optional().nullable(),
+        // Photographer profile fields
+        city: z.string().optional(),
+        country: z.string().optional(),
+        startingPrice: z.number().int().positive().optional(),
+        isPublished: z.boolean().optional(),
+        slug: z.string().optional()
       }),
       req.body
     );
 
-    const { verified, ...userData } = body;
+    const {
+      verified, location, bio, phone,
+      city, country, startingPrice, isPublished, slug,
+      ...userData
+    } = body;
 
-    if (verified !== undefined) {
+    // Handle photographer profile updates
+    const ppFields: Record<string, unknown> = {};
+    if (verified !== undefined) ppFields.verified = verified;
+    if (city !== undefined) ppFields.city = city;
+    if (country !== undefined) ppFields.country = country;
+    if (startingPrice !== undefined) ppFields.startingPrice = startingPrice;
+    if (isPublished !== undefined) ppFields.isPublished = isPublished;
+    if (slug !== undefined) ppFields.slug = slug;
+    if (bio !== undefined) ppFields.bio = bio;
+
+    if (Object.keys(ppFields).length > 0) {
       const pp = await prisma.photographerProfile.findUnique({ where: { userId: req.params.id } });
       if (pp) {
         await prisma.photographerProfile.update({
           where: { userId: req.params.id },
-          data: { verified }
+          data: ppFields
         });
       }
     }
 
-    const user = await prisma.user.update({ where: { id: req.params.id }, data: userData, include: userInclude });
+    // Handle client profile updates
+    const cpFields: Record<string, unknown> = {};
+    if (location !== undefined) cpFields.location = location;
+    if (bio !== undefined) cpFields.bio = bio;
+    if (phone !== undefined) cpFields.phone = phone;
+
+    if (Object.keys(cpFields).length > 0) {
+      const cp = await prisma.clientProfile.findUnique({ where: { userId: req.params.id } });
+      if (cp) {
+        await prisma.clientProfile.update({
+          where: { userId: req.params.id },
+          data: cpFields
+        });
+      } else if (body.role === Role.CLIENT || !body.role) {
+        // Create client profile if it doesn't exist and user is/is becoming a client
+        await prisma.clientProfile.create({
+          data: { userId: req.params.id, ...cpFields } as any
+        });
+      }
+    }
+
+    // Handle email uniqueness check
+    if (userData.email) {
+      userData.email = userData.email.toLowerCase();
+      const existing = await prisma.user.findFirst({
+        where: { email: userData.email, id: { not: req.params.id } }
+      });
+      if (existing) throw new AppError(409, "EMAIL_EXISTS", "Email already in use by another user");
+    }
+
+    const updateData = Object.keys(userData).length > 0 ? userData : {};
+    const user = await prisma.user.update({
+      where: { id: req.params.id },
+      data: updateData,
+      include: userInclude
+    });
     await audit(req.user!.id, "admin.user_update", "User", user.id, { ...body });
     ok(res, userResource(user));
   })

--- a/src/pages/admin/UserFormModal.tsx
+++ b/src/pages/admin/UserFormModal.tsx
@@ -1,0 +1,291 @@
+import { useEffect, useState } from "react";
+import { api, type User } from "../../lib/api";
+
+type FormData = {
+  name: string;
+  email: string;
+  password: string;
+  role: "ADMIN" | "CLIENT" | "PHOTOGRAPHER";
+  avatarUrl: string;
+  // Client fields
+  location: string;
+  bio: string;
+  phone: string;
+  // Photographer fields
+  city: string;
+  startingPrice: string;
+};
+
+type FormErrors = Partial<Record<keyof FormData, string>>;
+
+type UserFormModalProps = {
+  open: boolean;
+  user?: User | null;
+  onClose: () => void;
+  onSaved: () => void;
+};
+
+const emptyForm: FormData = {
+  name: "",
+  email: "",
+  password: "",
+  role: "CLIENT",
+  avatarUrl: "",
+  location: "",
+  bio: "",
+  phone: "",
+  city: "",
+  startingPrice: "",
+};
+
+export function UserFormModal({ open, user, onClose, onSaved }: UserFormModalProps) {
+  const isCreate = !user;
+  const [form, setForm] = useState<FormData>(emptyForm);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [saving, setSaving] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      if (user) {
+        setForm({
+          name: user.name,
+          email: user.email,
+          password: "",
+          role: user.role,
+          avatarUrl: user.avatarUrl ?? "",
+          location: user.clientProfile?.location ?? "",
+          bio: user.clientProfile?.bio ?? "",
+          phone: user.clientProfile?.phone ?? "",
+          city: user.photographerProfile?.city ?? "",
+          startingPrice: user.photographerProfile?.startingPrice ? String(user.photographerProfile.startingPrice) : "",
+        });
+      } else {
+        setForm(emptyForm);
+      }
+      setErrors({});
+      setServerError(null);
+    }
+  }, [open, user]);
+
+  function update<K extends keyof FormData>(key: K, value: FormData[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+    if (errors[key]) {
+      setErrors((prev) => ({ ...prev, [key]: undefined }));
+    }
+  }
+
+  function validate(): boolean {
+    const errs: FormErrors = {};
+    if (!form.name.trim()) errs.name = "Name is required";
+    if (!form.email.trim()) errs.email = "Email is required";
+    else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email)) errs.email = "Invalid email format";
+    if (isCreate && !form.password) errs.password = "Password is required";
+    else if (isCreate && form.password.length < 6) errs.password = "Password must be at least 6 characters";
+    if (form.avatarUrl && !/^https?:\/\//.test(form.avatarUrl)) errs.avatarUrl = "Must be a valid URL";
+    if (form.role === "PHOTOGRAPHER" && !form.city.trim()) errs.city = "City is required";
+    if (form.role === "PHOTOGRAPHER" && form.startingPrice && isNaN(Number(form.startingPrice))) errs.startingPrice = "Must be a number";
+    setErrors(errs);
+    return Object.keys(errs).length === 0;
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!validate()) return;
+
+    setSaving(true);
+    setServerError(null);
+
+    try {
+      const body: Record<string, unknown> = {
+        name: form.name.trim(),
+        email: form.email.trim(),
+        role: form.role,
+        avatarUrl: form.avatarUrl || null,
+      };
+
+      if (isCreate) {
+        body.password = form.password;
+      }
+
+      if (form.role === "CLIENT") {
+        body.location = form.location || null;
+        body.bio = form.bio || null;
+        body.phone = form.phone || null;
+      } else if (form.role === "PHOTOGRAPHER") {
+        body.city = form.city || "Toronto";
+        body.bio = form.bio || "Available for curated photography sessions.";
+        body.startingPrice = form.startingPrice ? Number(form.startingPrice) : 250;
+      }
+
+      if (isCreate) {
+        await api(`/admin/users`, { method: "POST", body });
+      } else {
+        await api(`/admin/users/${user!.id}`, { method: "PATCH", body });
+      }
+
+      onSaved();
+      onClose();
+    } catch (err: any) {
+      setServerError(err.message || "Failed to save user");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!open) return null;
+
+  return (
+    <div className="modal-overlay" onClick={onClose} role="dialog" aria-modal="true" aria-labelledby="user-form-title">
+      <div className="modal-card user-form-modal" onClick={(e) => e.stopPropagation()}>
+        <h2 id="user-form-title">{isCreate ? "Create User" : `Edit User: ${user!.name}`}</h2>
+
+        {serverError && <p className="form-error">{serverError}</p>}
+
+        <form onSubmit={handleSubmit} className="user-form">
+          <label>
+            Name *
+            <input
+              type="text"
+              value={form.name}
+              onChange={(e) => update("name", e.target.value)}
+              className={errors.name ? "input-error" : ""}
+              autoFocus
+            />
+            {errors.name && <span className="field-error">{errors.name}</span>}
+          </label>
+
+          <label>
+            Email *
+            <input
+              type="email"
+              value={form.email}
+              onChange={(e) => update("email", e.target.value)}
+              className={errors.email ? "input-error" : ""}
+            />
+            {errors.email && <span className="field-error">{errors.email}</span>}
+          </label>
+
+          {isCreate && (
+            <label>
+              Password *
+              <input
+                type="password"
+                value={form.password}
+                onChange={(e) => update("password", e.target.value)}
+                className={errors.password ? "input-error" : ""}
+              />
+              {errors.password && <span className="field-error">{errors.password}</span>}
+            </label>
+          )}
+
+          <label>
+            Avatar URL
+            <input
+              type="url"
+              value={form.avatarUrl}
+              onChange={(e) => update("avatarUrl", e.target.value)}
+              placeholder="https://example.com/avatar.jpg"
+              className={errors.avatarUrl ? "input-error" : ""}
+            />
+            {errors.avatarUrl && <span className="field-error">{errors.avatarUrl}</span>}
+          </label>
+
+          <label>
+            Role *
+            <select
+              value={form.role}
+              onChange={(e) => update("role", e.target.value as FormData["role"])}
+            >
+              <option value="CLIENT">Client</option>
+              <option value="PHOTOGRAPHER">Photographer</option>
+              <option value="ADMIN">Admin</option>
+            </select>
+          </label>
+
+          {/* Client-specific fields */}
+          {form.role === "CLIENT" && (
+            <div className="user-form-section">
+              <h4>Client Profile</h4>
+              <label>
+                Location
+                <input
+                  type="text"
+                  value={form.location}
+                  onChange={(e) => update("location", e.target.value)}
+                  placeholder="e.g. Toronto, ON"
+                />
+              </label>
+              <label>
+                Bio
+                <textarea
+                  value={form.bio}
+                  onChange={(e) => update("bio", e.target.value)}
+                  placeholder="Short bio..."
+                  rows={3}
+                />
+              </label>
+              <label>
+                Phone
+                <input
+                  type="text"
+                  value={form.phone}
+                  onChange={(e) => update("phone", e.target.value)}
+                  placeholder="e.g. +1 416-555-0123"
+                />
+              </label>
+            </div>
+          )}
+
+          {/* Photographer-specific fields */}
+          {form.role === "PHOTOGRAPHER" && (
+            <div className="user-form-section">
+              <h4>Photographer Profile</h4>
+              <label>
+                City *
+                <input
+                  type="text"
+                  value={form.city}
+                  onChange={(e) => update("city", e.target.value)}
+                  placeholder="e.g. Toronto"
+                  className={errors.city ? "input-error" : ""}
+                />
+                {errors.city && <span className="field-error">{errors.city}</span>}
+              </label>
+              <label>
+                Starting Price ($)
+                <input
+                  type="number"
+                  value={form.startingPrice}
+                  onChange={(e) => update("startingPrice", e.target.value)}
+                  placeholder="e.g. 250"
+                  min={0}
+                  className={errors.startingPrice ? "input-error" : ""}
+                />
+                {errors.startingPrice && <span className="field-error">{errors.startingPrice}</span>}
+              </label>
+              <label>
+                Bio
+                <textarea
+                  value={form.bio}
+                  onChange={(e) => update("bio", e.target.value)}
+                  placeholder="Short bio..."
+                  rows={3}
+                />
+              </label>
+            </div>
+          )}
+
+          <div className="modal-actions">
+            <button type="button" className="ghost-button" onClick={onClose} disabled={saving}>
+              Cancel
+            </button>
+            <button type="submit" className="solid-button" disabled={saving}>
+              {saving ? "Saving…" : isCreate ? "Create User" : "Save Changes"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/UsersTab.tsx
+++ b/src/pages/admin/UsersTab.tsx
@@ -1,12 +1,13 @@
 import {
   ArrowDown, ArrowUp, ArrowUpDown, BadgeCheck, ChevronLeft, ChevronRight,
-  Search, Trash2, UserCheck, UserX, X
+  Pencil, Plus, Search, Trash2, UserCheck, UserX, X
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { StatusBadge } from "../../components/StatusBadge";
 import { ConfirmDialog } from "../../components/shared/ConfirmDialog";
 import { useToast } from "../../components/shared/Toast";
 import { api, shortDate, type User } from "../../lib/api";
+import { UserFormModal } from "./UserFormModal";
 
 type SortField = "name" | "email" | "role" | "status" | "createdAt";
 type SortDir = "asc" | "desc";
@@ -54,6 +55,9 @@ export function UsersTab() {
 
   // Expandable rows
   const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  // User form modal (undefined = closed, null = create mode, User = edit mode)
+  const [formUser, setFormUser] = useState<User | undefined | null>(undefined);
 
   // Confirm dialogs
   const [confirmDelete, setConfirmDelete] = useState<User | null>(null);
@@ -266,6 +270,9 @@ export function UsersTab() {
           <select value={String(meta.limit)} onChange={(e) => setMeta((m) => ({ ...m, limit: Number(e.target.value), page: 1 }))} className="filter-select page-size-select">
             {PAGE_SIZES.map((s) => <option key={s} value={s}>{s} per page</option>)}
           </select>
+          <button className="solid-button compact" onClick={() => setFormUser(null)}>
+            <Plus size={14} /> Create User
+          </button>
         </div>
 
         {/* Bulk action bar */}
@@ -329,6 +336,7 @@ export function UsersTab() {
                     onRoleChange={(role) => setConfirmRole({ user, role })}
                     onToggleVerified={toggleVerified}
                     onDelete={() => setConfirmDelete(user)}
+                    onEdit={() => setFormUser(user)}
                   />
                 ))}
               </tbody>
@@ -412,13 +420,21 @@ export function UsersTab() {
         onConfirm={() => confirmBulk && executeBulk(confirmBulk.action, confirmBulk.ids)}
         onCancel={() => setConfirmBulk(null)}
       />
+
+      {/* Create / Edit user modal */}
+      <UserFormModal
+        open={formUser !== undefined}
+        user={formUser ?? null}
+        onClose={() => setFormUser(undefined)}
+        onSaved={() => { loadUsers(); toast.success(formUser === null ? "User created." : "User updated."); }}
+      />
     </div>
   );
 }
 
 function UserRow({
   user, isSelected, isExpanded, onToggleSelect, onToggleExpand,
-  actionButtons, onRoleChange, onToggleVerified, onDelete
+  actionButtons, onRoleChange, onToggleVerified, onDelete, onEdit
 }: {
   user: User;
   isSelected: boolean;
@@ -429,6 +445,7 @@ function UserRow({
   onRoleChange: (role: string) => void;
   onToggleVerified: (user: User) => void;
   onDelete: () => void;
+  onEdit: () => void;
 }) {
   const isPhotographer = user.role === "PHOTOGRAPHER";
   const pp = user.photographerProfile;
@@ -473,6 +490,9 @@ function UserRow({
                 <BadgeCheck size={14} className={pp?.verified ? "verified-icon" : "unverified-icon"} />
               </button>
             )}
+            <button className="ghost-button compact" onClick={onEdit} title="Edit user">
+              <Pencil size={14} />
+            </button>
             {actionButtons.map((btn, i) => (
               <button
                 key={i}

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -493,3 +493,46 @@
   border-radius: 4px;
   border: 1px solid var(--line);
 }
+
+/* User form modal */
+.user-form-modal {
+  width: min(520px, calc(100% - 32px));
+  max-height: 85vh;
+  overflow-y: auto;
+}
+
+.user-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.user-form-section {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 16px;
+  background: var(--wash);
+}
+
+.user-form-section h4 {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  margin: 0 0 12px 0;
+}
+
+.field-error {
+  color: var(--red);
+  font-weight: 600;
+  font-size: 0.78rem;
+  margin-top: -4px;
+}
+
+.input-error {
+  border-color: var(--red) !important;
+}
+
+.input-error:focus {
+  box-shadow: 0 0 0 3px var(--red-soft) !important;
+}


### PR DESCRIPTION
## Summary

Enhances the admin user management interface to allow admins to **create** and **edit** users of any type (ADMIN, CLIENT, PHOTOGRAPHER) via a dedicated form modal.

---

## Changes

### Backend: `server/routes/admin.routes.ts`

**Added `POST /admin/users`** — create user with any role:
- Accepts: `name`, `email`, `password`, `role` (required), plus optional `avatarUrl` and role-specific profile fields (`location`, `bio`, `phone` for CLIENT; `city`, `startingPrice` for PHOTOGRAPHER)
- Hashes password with bcrypt, auto-creates `ClientProfile` or `PhotographerProfile` based on role
- Auto-generates unique slug for photographers
- Logs audit trail entry

**Enhanced `PATCH /admin/users/:id`** — now supports editing:
- **User-level**: `name`, `email`, `avatarUrl`, `status`, `role`
- **Photographer profile**: `verified`, `city`, `country`, `startingPrice`, `isPublished`, `slug`, `bio`
- **Client profile**: `location`, `bio`, `phone`
- Email uniqueness validation (excluding the user being updated)

### Frontend: New `UserFormModal.tsx`

Reusable modal for creating/editing users:
- **Create mode**: name, email, password, avatar URL, role + role-specific fields
- **Edit mode**: same fields minus password (not changeable via this modal)
- **Role-adaptive form**: CLIENT → shows Location/Bio/Phone; PHOTOGRAPHER → shows City/Starting Price/Bio; ADMIN → no extra fields
- Client-side validation, server error display, loading states

### Frontend: Updated `UsersTab.tsx`

- **"Create User" button** added to the toolbar
- **Edit button** (pencil icon) added to each user row
- `UserFormModal` integrated with create/edit modes

### Styles: `admin.css`

Added styles for: `.user-form-modal`, `.user-form`, `.user-form-section`, `.field-error`, `.input-error`

---

## Verification

- ✅ TypeScript compiles with zero errors
- ✅ `npm run build` succeeds
- ✅ All 7 API tests pass