### PR TITLE
fix: compile server to JS for reliable Render deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+dist-server/
 .env
 .env.local
 dev.db

--- a/doc/FREE_HOSTING_GUIDE.md
+++ b/doc/FREE_HOSTING_GUIDE.md
@@ -67,22 +67,29 @@ That's it. The schema is already compatible — `@default(now())`, `@default(cui
 
 ---
 
-## Step 3: Update the `db:push` Script
+## Step 3: Update Build & Start Scripts
 
-The current `db:push` script uses a SQLite-specific workaround. Replace it with the standard Prisma command.
+The project now compiles the server TypeScript to JavaScript for production (instead of relying on `tsx` at runtime).
 
 **Edit `package.json`:**
 
-Find the `db:push` line in the `"scripts"` section and replace it with:
+Find the `"build"` and `"start"` lines and ensure they are:
 
 ```json
-"db:push": "prisma db push && prisma generate",
+"build": "tsc --noEmit && vite build && tsc -p tsconfig.server.json",
+"start": "node dist-server/server/index.js",
 ```
 
-> ⚠️ **Make sure the resulting JSON is valid.** The line should be exactly as above — a single string value. A common mistake is ending up with `"db:push": "db:push": "prisma db push..."` (duplicated key), which breaks JSON parsing.
+> The build command compiles:
+> 1. TypeScript type-checking (`tsc --noEmit`)
+> 2. Vite frontend build (`vite build`)
+> 3. Server TypeScript compilation to CommonJS (`tsc -p tsconfig.server.json`) which outputs to `dist-server/`
+>
+> The start command uses compiled Node.js instead of `tsx` for reliability and faster startup.
 
-Also add a migration script:
+Also ensure these helper scripts exist:
 ```json
+"db:push": "prisma db push && prisma generate",
 "db:migrate": "prisma migrate dev --name init",
 ```
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "concurrently -n api,web -c cyan,magenta \"npm:dev:api\" \"npm:dev:web\"",
     "dev:api": "tsx watch server/index.ts",
     "dev:web": "vite --host 0.0.0.0",
-    "build": "tsc --noEmit && vite build",
+    "build": "tsc --noEmit && vite build && tsc -p tsconfig.server.json",
     "lint": "eslint .",
     "pretest": "npm run db:reset",
     "test": "vitest run",
@@ -17,7 +17,7 @@
     "db:migrate": "prisma migrate dev --name init",
     "db:seed": "tsx prisma/seed.ts",
     "db:reset": "npm run db:push && npm run db:seed",
-    "start": "tsx server/index.ts"
+    "start": "node dist-server/server/index.js"
   },
   "dependencies": {
     "@prisma/client": "^6.7.0",

--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
     name: moussawer
     env: node
     buildCommand: npm install && npm run build && npx prisma db push && npx prisma generate
-    startCommand: npm run start
+    startCommand: node dist-server/server/index.js
     envVars:
       - key: NODE_ENV
         value: production

--- a/server/index.ts
+++ b/server/index.ts
@@ -43,4 +43,7 @@ async function main() {
   });
 }
 
-main();
+main().catch((err) => {
+  console.error("💥 Fatal error during startup:", err);
+  process.exit(1);
+});

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist-server",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "types": ["node"]
+  },
+  "include": ["server", "prisma"]
+}


### PR DESCRIPTION
## Summary

Fixes #87 — deploy exits with status 1 silently because of two compounded issues:

1. **`main()` lacks `.catch()` handler** — unhandled promise rejection exits with status 1 in Node 15+
2. **`tsx` is unreliable in production** — ESM resolution issues with `"type": "module"` in package.json cause silent crashes

## Changes

| File | Change |
|---|---|
| **`tsconfig.server.json`** (new) | Compiles server TypeScript to CommonJS in `dist-server/` |
| **`package.json`** | `build` compiles server too; `start` uses `node` not `tsx` |
| **`server/index.ts`** | Added `main().catch()` to log fatal errors |
| **`render.yaml`** | `startCommand` uses compiled JS directly |
| **`.gitignore`** | Added `dist-server/` |
| **`doc/FREE_HOSTING_GUIDE.md`** | Updated Step 3 docs to reflect new build/start commands |

## Why compiled JS instead of tsx?

- `tsx` adds startup overhead and can fail silently with ESM+CJS interop issues
- Compiled CommonJS JS is the standard Node.js production pattern
- The `build` script now: `tsc --noEmit && vite build && tsc -p tsconfig.server.json`
- The `start` script now: `node dist-server/server/index.js`

## Validation

- TypeScript compilation succeeds cleanly (exit 0)
- Output JS verified: CommonJS format with `.catch()` handler present
- `dist-server/` contains all server modules (app, config, db, openapi, routes, services, utils, middleware)