### PR TITLE
fix: add dist-server/package.json for CommonJS, remove Prisma beforeExit hook

### DIFF
--- a/doc/FREE_HOSTING_GUIDE.md
+++ b/doc/FREE_HOSTING_GUIDE.md
@@ -84,6 +84,7 @@ Find the `"build"` and `"start"` lines and ensure they are:
 > 1. TypeScript type-checking (`tsc --noEmit`)
 > 2. Vite frontend build (`vite build`)
 > 3. Server TypeScript compilation to CommonJS (`tsc -p tsconfig.server.json`) which outputs to `dist-server/`
+> 4. Writes `{"type":"commonjs"}` to `dist-server/package.json` so Node.js treats compiled `.js` files as CommonJS (because the root `package.json` has `"type": "module"`)
 >
 > The start command uses compiled Node.js instead of `tsx` for reliability and faster startup.
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "concurrently -n api,web -c cyan,magenta \"npm:dev:api\" \"npm:dev:web\"",
     "dev:api": "tsx watch server/index.ts",
     "dev:web": "vite --host 0.0.0.0",
-    "build": "tsc --noEmit && vite build && tsc -p tsconfig.server.json",
+    "build": "tsc --noEmit && vite build && tsc -p tsconfig.server.json && echo '{\"type\":\"commonjs\"}' > dist-server/package.json",
     "lint": "eslint .",
     "pretest": "npm run db:reset",
     "test": "vitest run",

--- a/server/db.ts
+++ b/server/db.ts
@@ -10,12 +10,6 @@ export const prisma =
     log: process.env.NODE_ENV === "development" ? ["warn", "error"] : ["error"]
   });
 
-// Set connection pool timeout to fail fast instead of hanging indefinitely
-// This is especially important for PgBouncer connections that may time out
-prisma.$on("beforeExit" as never, async () => {
-  await prisma.$disconnect();
-});
-
 if (process.env.NODE_ENV !== "production") {
   globalForPrisma.prisma = prisma;
 }


### PR DESCRIPTION
## What & Why

PR #95 was merged but the extra fixes pushed to the same branch after merge never made it to `main`. This PR completes the fix for #87 with two critical changes:

### Fix 1: ESM vs CommonJS mismatch
The root `package.json` has `"type": "module"`. Node.js 24 on Render treats all `.js` files as ES modules. The compiled CommonJS output uses `require()`/`exports` which don't exist in ESM scope, causing:

```
ReferenceError: exports is not defined in ES module scope
```

**Fix:** Build script now writes `{"type":"commonjs"}` to `dist-server/package.json` after compilation. Node.js respects nested `package.json` files — all `.js` files under `dist-server/` are treated as CommonJS.

### Fix 2: Prisma 6.x library engine removed `beforeExit` hook
`server/db.ts` had:
```ts
prisma.$on("beforeExit" as never, async () => { ... });
```

Prisma 6.19.3's library engine throws **immediately** on this call. This crashed the module before any code in `main()` could run, explaining the silent exit with status 1.

**Fix:** Removed the `beforeExit` hook (it was unused — the hook fires on `prisma.$disconnect()` which never happens in this app).

### File changes

| File | Change |
|---|---|
| `package.json` | Build writes `{"type":"commonjs"}` to `dist-server/package.json` |
| `server/db.ts` | Removed unsupported `$on("beforeExit")` hook |
| `doc/FREE_HOSTING_GUIDE.md` | Updated docs to explain the `dist-server/package.json` mechanism |

### Validation

The compiled server now starts correctly:
```
Moussawer API running on http://localhost:4000
API docs available at http://localhost:4000/api-docs
```